### PR TITLE
Use `__file__` for paths instead of `sys.path`

### DIFF
--- a/augly/utils/base_paths.py
+++ b/augly/utils/base_paths.py
@@ -2,11 +2,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import os
-import sys
 
+MODULE_BASE_PATH = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 # asset paths
-ASSETS_BASE_DIR = os.path.join(sys.path[1], "assets")
+ASSETS_BASE_DIR = os.path.join(MODULE_BASE_PATH, "assets")
 
 AUDIO_ASSETS_DIR = os.path.join(ASSETS_BASE_DIR, "audio")
 TEXT_DIR = os.path.join(ASSETS_BASE_DIR, "text")
@@ -19,8 +19,9 @@ TEMPLATE_PATH = os.path.join(SCREENSHOT_TEMPLATES_DIR, "web.png")
 TEST_URI = os.path.join(ASSETS_BASE_DIR, "tests")
 
 # test paths
-METADATA_BASE_PATH = os.path.join(sys.path[1], "augly", "utils", "expected_output")
+METADATA_BASE_PATH = os.path.join(MODULE_BASE_PATH, "augly", "utils", "expected_output")
 METADATA_FILENAME = "expected_metadata.json"
+
 AUDIO_METADATA_PATH = os.path.join(METADATA_BASE_PATH, "audio_tests", METADATA_FILENAME)
 IMAGE_METADATA_PATH = os.path.join(METADATA_BASE_PATH, "image_tests", METADATA_FILENAME)
 TEXT_METADATA_PATH = os.path.join(METADATA_BASE_PATH, "text_tests", METADATA_FILENAME)


### PR DESCRIPTION
Using `sys.path` to determine the paths in `base_paths.py` is hacky and only works if your Python path is set **very specifically**.

Instead let's get the file paths in `base_paths.py` by using `__file__` and getting the parent directories' names :)

Ran transforms test for each modality to ensure everything runs as expected:
```
$ ~/anaconda3/envs/augly/bin/python -m unittest augly.tests.text_tests.transforms_unit_tests
----------------------------------------------------------------------
Ran 12 tests in 0.013s

OK
```

```
$ ~/anaconda3/envs/augly/bin/python -m unittest augly.tests.image_tests.transforms_unit_tests
----------------------------------------------------------------------
Ran 39 tests in 14.366s

OK
```

```
$ ~/anaconda3/envs/augly/bin/python -m unittest augly.tests.audio_tests.transforms_unit_tests
----------------------------------------------------------------------
Ran 24 tests in 7.878s

OK

```

```
$ ~/anaconda3/envs/augly/bin/python -m unittest augly.tests.video_tests.transforms.composite_tests

----------------------------------------------------------------------
Ran 11 tests in 29.982s

OK
```