### PR TITLE
Fix `README.md` links

### DIFF
--- a/augly/audio/README.md
+++ b/augly/audio/README.md
@@ -2,9 +2,9 @@
 
 ## Augmentations
 
-For a full list of available augmentations, see [here](augly/audio/__init__.py).
+For a full list of available augmentations, see [here](__init__.py).
 
-Our audio augmentations use librosa, torchaudio, and NumPy as the backend. All functions accept an audio path or an audio array to be augmented as input and return the augmented audio array. If an output path is specified, the audio will also be saved to a file.
+Our audio augmentations use `librosa`, `torchaudio`, and NumPy as their backend. All functions accept an audio path or an audio array to be augmented as input and return the augmented audio array. If an output path is specified, the audio will also be saved to a file.
 
 ### Function-based
 
@@ -55,7 +55,7 @@ aug_audio = TRANSFORMS(audio_array)
 
 ## Unit Tests
 
-You can run our audio unit tests if you have cloned `augly` [here](augly/README.md)) by running the following:
+You can run our audio unit tests if you have cloned `augly` [here](../../README.md)) by running the following:
 ```bash
 python -m unittest augly.tests.audio_tests.functional_unit_tests
 python -m unittest augly.tests.audio_tests.transforms_unit_tests

--- a/augly/image/README.md
+++ b/augly/image/README.md
@@ -2,9 +2,9 @@
 
 ## Augmentations
 
-For a full list of available augmentations, see [here](augly/image/__init__.py).
+For a full list of available augmentations, see [here](__init__.py).
 
-Our image augmentations use PIL as the backend. All functions accept a path to the image or a PIL Image object to be augmented as input and return the augmented PIL Image object. If an output path is specified, the image will also be saved to a file.
+Our image augmentations use `PIL` as their backend. All functions accept a path to the image or a PIL Image object to be augmented as input and return the augmented PIL Image object. If an output path is specified, the image will also be saved to a file.
 
 ### Function-based
 
@@ -69,7 +69,7 @@ np_aug_img = aug_np_wrapper(np_image, overlay_emoji, **{'opacity': 0.5, 'y_pos':
 
 ## Unit Tests
 
-You can run our image unit tests if you have cloned `augly` (see [here](augly/README.md)) by running the following:
+You can run our image unit tests if you have cloned `augly` (see [here](../../README.md)) by running the following:
 ```bash
 python -m unittest augly.tests.image_tests.functional_unit_tests
 python -m unittest augly.tests.image_tests.transforms_unit_tests

--- a/augly/text/README.md
+++ b/augly/text/README.md
@@ -2,9 +2,9 @@
 
 ## Augmentations
 
-For a full list of available augmentations, see [here](augly/text/__init__.py).
+For a full list of available augmentations, see [here](__init__.py).
 
-Our text augmentations use nlpaug as its backbone. All functions accept a list of original texts to be augmented as input and return the list of augmented texts.
+Our text augmentations use `nlpaug` as their backbone. All functions accept a list of original texts to be augmented as input and return the list of augmented texts.
 
 ### Function-based
 
@@ -35,7 +35,7 @@ aug_texts = transform(texts)
 
 ## Unit Tests
 
-You can run our text unit tests if you have cloned `augly` (see [here](augly/README.md)) by running the following:
+You can run our text unit tests if you have cloned `augly` (see [here](../../README.md)) by running the following:
 ```
 python -m unittest augly.tests.text_tests.functional_unit_tests
 python -m unittest augly.tests.text_tests.transforms_unit_tests


### PR DESCRIPTION
Some of the links in our READMEs were pointing to the wrong paths. This PR fixes that. We fix the video library README in [pull/5](https://github.com/facebookresearch/AugLy/pull/5), so this PR focuses on fixing the audio, image, & text libraries