### PR TITLE
Change year from 2020 -> 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ We provide various media assets to use with some of our augmentations. These ass
 If you use AugLy in your work, please cite:
 
 ```bibtex
-@misc{bitton2020augly,
+@misc{bitton2021augly,
   author =       {Bitton, Joanna and Papakipos, Zoe},
   title =        {AugLy: A data augmentations library for audio, image, text, and video.},
   howpublished = {\url{https://github.com/facebookresearch/AugLy}},


### PR DESCRIPTION
Summary: The citation for our library accidentally used the year 2020 instead of 2021

Reviewed By: zpapakipos

Differential Revision: D29202026

