### PR TITLE
Update `torchaudio` to 0.9 for `tensorflow-gpu` compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ llvmlite==0.36.0
 matplotlib==3.3.4
 nlpaug==1.1.3
 numba==0.53.1
-numpy==1.20.2
+numpy>=1.19.5
 olefile==0.46
 opencv-python==4.5.2.54
 packaging==20.9
@@ -25,7 +25,6 @@ Pillow==8.2.0
 pooch==1.3.0
 portalocker==2.3.0
 pycparser==2.20
-pyOpenSSL==20.0.1
 pyparsing==2.4.7
 PySocks==1.7.1
 python-dateutil==2.8.1
@@ -39,8 +38,8 @@ scipy==1.6.2
 six==1.15.0
 SoundFile==0.10.3.post1
 threadpoolctl==2.1.0
-torch==1.8.1
-torchaudio==0.8.1
+torch==1.9.0
+torchaudio==0.9.0
 tornado==6.1
 tqdm==4.59.0
 typing-extensions==3.7.4.3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", encoding="utf8") as f:
 
 setuptools.setup(
     name="augly",
-    version="0.1.1",
+    version="0.1.2",
     description="A data augmentations library for audio, image, text, & video.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -3,20 +3,24 @@
 
 import setuptools
 from pathlib import Path
-from typing import Dict
 
 
 requirements = [
     r
-    for r in Path(f"requirements.txt").read_text().splitlines()
+    for r in Path("requirements.txt").read_text().splitlines()
     if '@' not in r
 ]
+
+with open("README.md", encoding="utf8") as f:
+    readme = f.read()
 
 
 setuptools.setup(
     name="augly",
     version="0.1.1",
     description="A data augmentations library for audio, image, text, & video.",
+    long_description=readme,
+    long_description_content_type="text/markdown",
     url="https://github.com/facebookresearch/AugLy",
     author="Zoe Papakipos and Joanna Bitton",
     author_email="zoep@fb.com",


### PR DESCRIPTION
Summary:
As called out in https://github.com/facebookresearch/AugLy/issues/28, there are some conflicting dependencies between `torchaudio`/`torch` 0.8.1/1.8.1 and `tensorflow-gpu`.

However, as discovered in https://github.com/pytorch/audio/issues/1595, upgrading to v0.9 etc actually resolve this issue.

Thus, I update the torchaudio/torch versions in our `requirements.txt` and I also updated our `numpy` requirement so there are no conflicting dependencies between `tf-gpu` and `augly` :)

I verified on my side that all unit tests still pass and that `setup.py` finishes as expected with no errors. I also update `setup.py` to add our README to our PyPI page.

Ran:
```
python -m unittest augly.tests.audio_tests.functional_unit_tests
----------------------------------------------------------------------
Ran 21 tests in 4.683s

OK

python -m unittest augly.tests.audio_tests.transforms_unit_tests
----------------------------------------------------------------------
Ran 24 tests in 1.892s

OK

python -m unittest augly.tests.image_tests.functional_unit_tests
----------------------------------------------------------------------
Ran 32 tests in 32.442s

OK (skipped=2)

python -m unittest augly.tests.image_tests.transforms_unit_tests
----------------------------------------------------------------------
Ran 39 tests in 12.182s

OK (skipped=3)

python -m unittest augly.tests.video_tests.transforms.cv2_tests
----------------------------------------------------------------------
Ran 5 tests in 72.686s

OK
```

and

```
python setup.py install
.....
Using /home/jbitton/anaconda3/envs/testing_reqs/lib/python3.9/site-packages
Finished processing dependencies for augly==0.1.1
```

Differential Revision: D29292956

