### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/augly/audio/functional.py
+++ b/augly/audio/functional.py
@@ -132,7 +132,7 @@ def apply_lambda(
     @param sample_rate: the audio sample rate of the inputted audio
 
     @param aug_function: the augmentation function to be applied onto the audio (should
-        expect the audio nd.nparray & sample rate int as input, and return the
+        expect the audio np.nparray & sample rate int as input, and return the
         transformed audio & sample rate)
 
     @param output_path: the path in which the resulting audio will be stored. If None,
@@ -701,7 +701,7 @@ def normalize(
 
     @param norm: the type of norm to compute:
         - np.inf: maximum absolute value
-        - -np.inf: mininum absolute value
+        - -np.inf: minimum absolute value
         - 0: number of non-zeros (the support)
         - float: corresponding l_p norm
         - None: no normalization is performed

--- a/augly/audio/functional.py
+++ b/augly/audio/functional.py
@@ -132,7 +132,7 @@ def apply_lambda(
     @param sample_rate: the audio sample rate of the inputted audio
 
     @param aug_function: the augmentation function to be applied onto the audio (should
-        expect the audio np.nparray & sample rate int as input, and return the
+        expect the audio np.ndarray & sample rate int as input, and return the
         transformed audio & sample rate)
 
     @param output_path: the path in which the resulting audio will be stored. If None,

--- a/augly/audio/transforms.py
+++ b/augly/audio/transforms.py
@@ -144,7 +144,7 @@ class ApplyLambda(BaseTransform):
     ):
         """
         @param aug_function: the augmentation function to be applied onto the audio
-            (should expect the audio np.nparray & sample rate int as input, and return
+            (should expect the audio np.ndarray & sample rate int as input, and return
             the transformed audio & sample rate)
 
         @param p: the probability of the transform being applied; default value is 1.0

--- a/augly/audio/transforms.py
+++ b/augly/audio/transforms.py
@@ -144,7 +144,7 @@ class ApplyLambda(BaseTransform):
     ):
         """
         @param aug_function: the augmentation function to be applied onto the audio
-            (should expect the audio nd.nparray & sample rate int as input, and return
+            (should expect the audio np.nparray & sample rate int as input, and return
             the transformed audio & sample rate)
 
         @param p: the probability of the transform being applied; default value is 1.0
@@ -496,7 +496,7 @@ class Normalize(BaseTransform):
         """
         @param norm: the type of norm to compute:
             - np.inf: maximum absolute value
-            - -np.inf: mininum absolute value
+            - -np.inf: minimum absolute value
             - 0: number of non-zeros (the support)
             - float: corresponding l_p norm
             - None: no normalization is performed

--- a/augly/image/functional.py
+++ b/augly/image/functional.py
@@ -758,7 +758,7 @@ def overlay_emoji(
 
     @param emoji_size: size of the emoji is emoji_size * height of the original image
 
-    @param x_pos: postion of emoji relative to the image width
+    @param x_pos: position of emoji relative to the image width
 
     @param y_pos: position of emoji relative to the image height
 
@@ -821,7 +821,7 @@ def overlay_image(
     @param overlay_size: size of the overlaid image is overlay_size * height
         of the original image
 
-    @param x_pos: postion of overlaid image relative to the image width
+    @param x_pos: position of overlaid image relative to the image width
 
     @param y_pos: position of overlaid image relative to the image height
 

--- a/augly/image/transforms.py
+++ b/augly/image/transforms.py
@@ -663,7 +663,7 @@ class OverlayEmoji(BaseTransform):
 
         @param emoji_size: size of the emoji is emoji_size * height of the original image
 
-        @param x_pos: postion of emoji relative to the image width
+        @param x_pos: position of emoji relative to the image width
 
         @param y_pos: position of emoji relative to the image height
 
@@ -718,7 +718,7 @@ class OverlayImage(BaseTransform):
         @param overlay_size: size of the overlaid image is overlay_size * height
             of the original image
 
-        @param x_pos: postion of overlaid image relative to the image width
+        @param x_pos: position of overlaid image relative to the image width
 
         @param y_pos: position of overlaid image relative to the image height
 
@@ -1455,7 +1455,7 @@ class RandomEmojiOverlay(BaseTransform):
 
         @param emoji_size: size of the emoji is emoji_size * height of the original image
 
-        @param x_pos: postion of emoji relative to the image width
+        @param x_pos: position of emoji relative to the image width
 
         @param y_pos: position of emoji relative to the image height
 

--- a/augly/video/augmenters/ffmpeg/overlay.py
+++ b/augly/video/augmenters/ffmpeg/overlay.py
@@ -20,7 +20,7 @@ class VideoAugmenterByOverlay(BaseFFMPEGAugmenter):
     ):
         assert is_image_file(overlay_path) or is_video_file(
             overlay_path
-        ), "Overlayed media type not supported: please overlay either an image or video"
+        ), "Overlaid media type not supported: please overlay either an image or video"
         assert 0 <= x_factor <= 1, "x_factor must be a value in the range [0, 1]"
         assert 0 <= y_factor <= 1, "y_factor must be a value in the range [0, 1]"
         assert (

--- a/augly/video/functional.py
+++ b/augly/video/functional.py
@@ -166,9 +166,9 @@ def blend_videos(
     @param overlay_size: size of the overlaid video is overlay_size * height of
         the background video
 
-    @param x_pos: postion of overlaid video relative to the background video width
+    @param x_pos: position of overlaid video relative to the background video width
 
-    @param y_pos: postion of overlaid video relative to the background video height
+    @param y_pos: position of overlaid video relative to the background video height
 
     @param use_second_audio: use the audio of the overlaid video rather than the audio
         of the background video
@@ -883,7 +883,7 @@ def overlay(
     @param video_path: the path to the video to be augmented
 
     @param overlay_path: the path to the media (image or video) that will be
-        overlayed onto the video
+        overlaid onto the video
 
     @param output_path: the path in which the resulting video will be stored.
         If not passed in, the original video file will be overwritten
@@ -891,14 +891,14 @@ def overlay(
     @param overlay_size: size of the overlaid media with respect to the background
         video. If set to None, the original size of the overlaid media is used
 
-    @param x_factor: specifies where the left side of the overlayed media should be
+    @param x_factor: specifies where the left side of the overlaid media should be
         placed, relative to the video width
 
-    @param y_factor: specifies where the top side of the overlayed media should be
+    @param y_factor: specifies where the top side of the overlaid media should be
         placed, relative to the video height
 
     @param use_overlay_audio: if set to True and the media type is a video, the audio
-        of the overlayed video will be used instead of the main/background video's audio
+        of the overlaid video will be used instead of the main/background video's audio
 
     @param metadata: if set to be a list, metadata about the function execution
         including its name, the source & dest duration, fps, etc. will be appended
@@ -1075,10 +1075,10 @@ def overlay_onto_background_video(
     @param overlay_size: size of the overlaid media with respect to the background
         video. If set to None, the original size of the overlaid media is used
 
-    @param x_factor: specifies where the left side of the overlayed media should be
+    @param x_factor: specifies where the left side of the overlaid media should be
         placed, relative to the video width
 
-    @param y_factor: specifies where the top side of the overlayed media should be
+    @param y_factor: specifies where the top side of the overlaid media should be
         placed, relative to the video height
 
     @param use_background_audio: if set to True and the media type is a video, the

--- a/augly/video/transforms.py
+++ b/augly/video/transforms.py
@@ -288,9 +288,9 @@ class BlendVideos(BaseTransform):
         @param overlay_size: size of the overlaid video is overlay_size * height of the
             background video
 
-        @param x_pos: postion of overlaid video relative to the background video width
+        @param x_pos: position of overlaid video relative to the background video width
 
-        @param y_pos: postion of overlaid video relative to the background video height
+        @param y_pos: position of overlaid video relative to the background video height
 
         @param use_second_audio: use the audio of the overlaid video rather than the
             audio of the background video
@@ -1002,19 +1002,19 @@ class Overlay(BaseTransform):
     ):
         """
         @param overlay_path: the path to the media (image or video) that will be
-            overlayed onto the video
+            overlaid onto the video
 
         @param overlay_size: size of the overlaid media with respect to the background
             video. If set to None, the original size of the overlaid media is used
 
-        @param x_factor: specifies where the left side of the overlayed media should be
+        @param x_factor: specifies where the left side of the overlaid media should be
             placed, relative to the video width
 
-        @param y_factor: specifies where the top side of the overlayed media should be
+        @param y_factor: specifies where the top side of the overlaid media should be
             placed, relative to the video height
 
         @param use_overlay_audio: if set to True and the media type is a video, the
-            audio of the overlayed video will be used instead of the main/background
+            audio of the overlaid video will be used instead of the main/background
             video's audio
 
         @param p: the probability of the transform being applied; default value is 1.0
@@ -1192,10 +1192,10 @@ class OverlayOntoBackgroundVideo(BaseTransform):
         @param overlay_size: size of the overlaid media with respect to the background
             video. If set to None, the original size of the overlaid media is used
 
-        @param x_factor: specifies where the left side of the overlayed media should be
+        @param x_factor: specifies where the left side of the overlaid media should be
             placed, relative to the video width
 
-        @param y_factor: specifies where the top side of the overlayed media should be
+        @param y_factor: specifies where the top side of the overlaid media should be
             placed, relative to the video height
 
         @param use_background_audio: if set to True and the media type is a video, the
@@ -2241,7 +2241,7 @@ class RandomEmojiOverlay(BaseTransform):
         @param emoji_size: size of the emoji is emoji_size * height of the
             original video
 
-        @param x_factor: postion of emoji relative to the video width
+        @param x_factor: position of emoji relative to the video width
 
         @param y_factor: position of emoji relative to the video height
 


### PR DESCRIPTION
Discovered in #50

$ [`codespell --skip="*/misspelling.json"`](https://github.com/codespell-project/codespell)
```
./augly/video/transforms.py:291: postion ==> position
./augly/video/transforms.py:293: postion ==> position
./augly/video/transforms.py:1005: overlayed ==> overlaid
./augly/video/transforms.py:1010: overlayed ==> overlaid
./augly/video/transforms.py:1013: overlayed ==> overlaid
./augly/video/transforms.py:1017: overlayed ==> overlaid
./augly/video/transforms.py:1195: overlayed ==> overlaid
./augly/video/transforms.py:1198: overlayed ==> overlaid
./augly/video/transforms.py:2244: postion ==> position
./augly/video/functional.py:169: postion ==> position
./augly/video/functional.py:171: postion ==> positions
./augly/video/functional.py:886: overlayed ==> overlaid
./augly/video/functional.py:894: overlayed ==> overlaid
./augly/video/functional.py:897: overlayed ==> overlaid
./augly/video/functional.py:901: overlayed ==> overlaid
./augly/video/functional.py:1078: overlayed ==> overlaid
./augly/video/functional.py:1081: overlayed ==> overlaid
./augly/video/augmenters/ffmpeg/overlay.py:23: Overlayed ==> Overlaid
./augly/tests/text_tests/functional_unit_tests.py:68: fo ==> of, for
./augly/tests/text_tests/functional_unit_tests.py:122: fo ==> of, for
./augly/tests/text_tests/functional_unit_tests.py:172: nwo ==> now
./augly/tests/text_tests/functional_unit_tests.py:172: coul ==> could
./augly/tests/text_tests/functional_unit_tests.py:177: coul ==> could
./augly/tests/text_tests/functional_unit_tests.py:196: coul ==> could
./augly/tests/text_tests/functional_unit_tests.py:305: Tje ==> The
./augly/tests/text_tests/functional_unit_tests.py:309: Teh ==> The
./augly/tests/text_tests/functional_unit_tests.py:320: hten ==> then, hen, the
./augly/tests/text_tests/transforms_unit_tests.py:176: coul ==> could
./augly/tests/text_tests/transforms_unit_tests.py:191: coul ==> could
./augly/tests/text_tests/transforms_unit_tests.py:221: Hte ==> The
./augly/image/transforms.py:666: postion ==> position
./augly/image/transforms.py:721: postion ==> position
./augly/image/transforms.py:1458: postion ==> position
./augly/image/functional.py:761: postion ==> position
./augly/image/functional.py:824: postion ==> position
./augly/text/augmenters/utils.py:82: tha ==> than, that, the
./augly/audio/transforms.py:147: nd ==> and, 2nd
./augly/audio/transforms.py:499: mininum ==> minimum
./augly/audio/functional.py:135: nd ==> and, 2nd
./augly/audio/functional.py:704: mininum ==> minimum
```