### PR TITLE
Remove IGFilter from image README

### DIFF
--- a/augly/image/README.md
+++ b/augly/image/README.md
@@ -42,7 +42,7 @@ COLOR_JITTER_PARAMS = {
 }
 
 AUGMENTATIONS = [
-    imaugs.IGFilter(),
+    imaugs.Blur(),
     imaugs.ColorJitter(**COLOR_JITTER_PARAMS),
     imaugs.OneOf(
         [imaugs.ScreenshotOverlay(), imaugs.EmojiOverlay(), imaugs.TextOverlay()]


### PR DESCRIPTION
Summary: We didn't open source IGFilter but had an example that used it in our image README, as pointed out in https://github.com/facebookresearch/AugLy/issues/42.

Reviewed By: jbitton

Differential Revision: D29298224

