### PR TITLE
Fix function names in `image` README

### DIFF
--- a/augly/image/README.md
+++ b/augly/image/README.md
@@ -51,7 +51,7 @@ AUGMENTATIONS = [
     imaugs.Blur(),
     imaugs.ColorJitter(**COLOR_JITTER_PARAMS),
     imaugs.OneOf(
-        [imaugs.ScreenshotOverlay(), imaugs.EmojiOverlay(), imaugs.TextOverlay()]
+        [imaugs.OverlayOntoScreenshot(), imaugs.OverlayEmoji(), imaugs.OverlayText()]
     ),
 ]
 


### PR DESCRIPTION
## Related Issue
Fixes #78

## Summary
We accidentally had old names of transforms in our image README -- this PR fixes that