### PR TITLE
Remove IG filter example from README

### DIFF
--- a/augly/image/README.md
+++ b/augly/image/README.md
@@ -25,7 +25,7 @@ output_path = "your_output_path.png"
 
 # Augmentation functions can accept image paths as input and
 # always return the resulting augmented PIL Image
-aug_image = imaugs.apply_ig_filter(image_path, filter_name="clarendon")
+aug_image = imaugs.overlay_emoji(image_path, opacity=1.0, emoji_size=0.15)
 
 # Augmentation functions can also accept PIL Images as input
 aug_image = imaugs.pad_square(aug_image)


### PR DESCRIPTION
Summary: IG filters are not yet shared publicly and therefore removing it from README

Fixes: #82 

Reviewed By: jbitton

Differential Revision: D29738319

