### PR TITLE
Fix `nlpaug` version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 iopath>=0.1.8
-nlpaug>=1.1.3
+nlpaug>=1.1.3,<1.1.5
 numpy>=1.19.5
 Pillow>=8.2.0
 python-magic>=0.4.22


### PR DESCRIPTION
## Summary
Until https://github.com/makcedward/nlpaug/pull/232 lands, we shouldn't use the latest version of `nlpaug`, as it is missing a requirement. This PR should fix the failed tests seen [here](https://github.com/facebookresearch/AugLy/pull/84/checks?check_run_id=3088839972).

Will confirm that the tests now pass here too :)

