### PR TITLE
Do not modify input image in `overlay_stripes`

### DIFF
--- a/augly/image/functional.py
+++ b/augly/image/functional.py
@@ -1033,16 +1033,17 @@ def overlay_stripes(
     mask = Image.fromarray(np.uint8(binary_mask * line_opacity * 255))
 
     foreground = Image.new("RGB", image.size, line_color)
-    image.paste(foreground, (0, 0), mask=mask)
+    aug_image = image.copy()  # to avoid modifying the input image
+    aug_image.paste(foreground, (0, 0), mask=mask)
 
     imutils.get_metadata(
         metadata=metadata,
         function_name="overlay_stripes",
-        aug_image=image,
+        aug_image=aug_image,
         **func_kwargs,
     )
 
-    return imutils.ret_and_save_image(image, output_path)
+    return imutils.ret_and_save_image(aug_image, output_path)
 
 
 def overlay_text(

--- a/augly/tests/image_tests/base_unit_test.py
+++ b/augly/tests/image_tests/base_unit_test.py
@@ -69,9 +69,7 @@ class BaseImageUnitTest(unittest.TestCase):
 
         img_path, img_file = cls.config.get_input_path()
         cls.local_img_path = pathmgr.get_local_path(img_path)
-
-    def setUp(self):
-        self.img = Image.open(self.local_img_path)
+        cls.img = Image.open(cls.local_img_path)
 
     def evaluate_function(self, aug_function: Callable[..., Image.Image], **kwargs):
         ref = self.get_ref_image(aug_function.__name__)


### PR DESCRIPTION
## Related Issue
Fixes #80 

## Summary
As mentioned in #80, `overlay_stripes` modifies the input image. We've known this for a while and have been meaning to fix it, so let's just do it :)

## Unit Tests: Image

functional: `python -m unittest augly.tests.image_tests.functional_unit_test`

```bash
----------------------------------------------------------------------
Ran 32 tests in 27.159s

OK (skipped=2)
```

transforms: `python -m unittest augly.tests.image_tests.transforms_unit_test`

```bash
----------------------------------------------------------------------
Ran 39 tests in 8.241s

OK (skipped=3)
```


