### PR TITLE
Update PyPI version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 iopath>=0.1.8
-nlpaug>=1.1.3,<1.1.5
+nlpaug==1.1.3
 numpy>=1.19.5
 Pillow>=8.2.0
 python-magic>=0.4.22

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("README.md", encoding="utf8") as f:
 
 setuptools.setup(
     name="augly",
-    version="0.1.5",
+    version="0.1.6",
     description="A data augmentations library for audio, image, text, & video.",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Related Issue
Fixes #86 

## Summary
The newer versions of `nlpaug` seem to be a tad buggy -- to assure that no issues arise in our library, we're gonna keep the `nlpaug` version at 1.1.3. Note that you may have to additionally install `torch` to get text augmentations to work, despite the fact that it's unneeded in the code we use from `nlpaug`
