### PR TITLE
Add metadata arg to Compose operator, add unit test

### DIFF
--- a/augly/tests/video_tests/transforms/composite_test.py
+++ b/augly/tests/video_tests/transforms/composite_test.py
@@ -30,6 +30,19 @@ class TransformsVideoUnitTest(BaseVideoUnitTest):
             metadata_exclude_keys=["dst_duration", "dst_fps", "intensity"],
         )
 
+    def test_Compose(self):
+        random.seed(1)
+        self.evaluate_class(
+            vidaugs.Compose(
+                [
+                    vidaugs.VFlip(),
+                    vidaugs.Brightness(),
+                    vidaugs.OneOf([vidaugs.Grayscale(), vidaugs.ApplyLambda()]),
+                ]
+            ),
+            fname="compose",
+        )
+
     def test_OverlayEmoji(self):
         self.evaluate_class(vidaugs.OverlayEmoji(), fname="overlay_emoji")
 

--- a/augly/utils/expected_output/video_tests/expected_metadata.json
+++ b/augly/utils/expected_output/video_tests/expected_metadata.json
@@ -191,6 +191,51 @@
       "src_width": 1920
     }
   ],
+  "compose": [
+    {
+      "name": "vflip",
+      "src_duration": 10.027855,
+      "dst_duration": 10.027855,
+      "src_fps": 29.916666666666668,
+      "dst_fps": 29.916666666666668,
+      "src_width": 1920,
+      "src_height": 1080,
+      "dst_width": 1920,
+      "dst_height": 1080,
+      "src_segments": [{"start": 0.0, "end": 10.027855}],
+      "dst_segments": [{"start": 0.0, "end": 10.027855}],
+      "intensity": 100.0
+    },
+    {
+      "name": "brightness",
+      "src_duration": 10.027855,
+      "dst_duration": 10.027855,
+      "src_fps": 29.916666666666668,
+      "dst_fps": 29.916666666666668,
+      "src_width": 1920,
+      "src_height": 1080,
+      "dst_width": 1920,
+      "dst_height": 1080,
+      "src_segments": [{"start": 0.0, "end": 10.027855}],
+      "dst_segments": [{"start": 0.0, "end": 10.027855}],
+      "level": 0.15,
+      "intensity": 15.0
+    },
+    {
+      "name": "grayscale",
+      "src_duration": 10.027855,
+      "dst_duration": 10.027855,
+      "src_fps": 29.916666666666668,
+      "dst_fps": 29.916666666666668,
+      "src_width": 1920,
+      "src_height": 1080,
+      "dst_width": 1920,
+      "dst_height": 1080,
+      "src_segments": [{"start": 0.0, "end": 10.027855}],
+      "dst_segments": [{"start": 0.0, "end": 10.027855}],
+      "intensity": 100.0
+    }
+  ],
   "contrast": [
     {
       "dst_duration": 10.027855,

--- a/augly/video/composition.py
+++ b/augly/video/composition.py
@@ -3,7 +3,7 @@
 
 import random
 import shutil
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from augly.video.transforms import VidAugBaseClass
 from augly.video.helpers import validate_input_and_output_paths
@@ -24,12 +24,11 @@ probabilities of the individual transforms.
 Example:
 
  >>> Compose([
- >>>     IGFilter(),
- >>>     ColorJitter(saturation_factor=1.5)
+ >>>     VFlip(),
+ >>>     Brightness(),
  >>>     OneOf([
- >>>         ScreenshotOverlay(),
- >>>         EmojiOverlay(),
- >>>         TextOverlay(),
+ >>>         OverlayOntoScreenshot(),
+ >>>         OverlayText(),
  >>>     ]),
  >>> ])
 """
@@ -52,7 +51,13 @@ class BaseComposition(VidAugBaseClass):
 
 
 class Compose(BaseComposition):
-    def __call__(self, video_path: str, output_path: Optional[str] = None) -> None:
+    def __call__(
+        self,
+        video_path: str,
+        output_path: Optional[str] = None,
+        seed: Optional[int] = None,
+        metadata: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
         """
         Applies the list of transforms in order to the video
 
@@ -60,6 +65,15 @@ class Compose(BaseComposition):
 
         @param output_path: the path in which the resulting video will be stored.
             If not passed in, the original video file will be overwritten
+
+        @param seed: if provided, the random seed will be set to this before calling
+            the transform
+
+        @param metadata: if set to be a list, metadata about the function execution
+            including its name, the source & dest duration, fps, etc. will be appended
+            to the inputted list. If set to None, no metadata will be appended or returned
+
+        @returns: the path to the augmented video
         """
         video_path, output_path = validate_input_and_output_paths(
             video_path, output_path
@@ -68,8 +82,12 @@ class Compose(BaseComposition):
         if video_path != output_path:
             shutil.copy(video_path, output_path)
 
+        if seed is not None:
+            random.seed(seed)
+
         for transform in self.transforms:
-            transform(output_path)
+            output_path = transform(output_path, metadata=metadata)
+        return output_path
 
 
 class OneOf(BaseComposition):
@@ -85,7 +103,13 @@ class OneOf(BaseComposition):
         probs_sum = sum(transform_probs)
         self.transform_probs = [t / probs_sum for t in transform_probs]
 
-    def __call__(self, video_path: str, output_path: Optional[str] = None) -> None:
+    def __call__(
+        self,
+        video_path: str,
+        output_path: Optional[str] = None,
+        seed: Optional[int] = None,
+        metadata: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
         """
         Applies one of the transforms to the video (with probability p)
 
@@ -93,9 +117,25 @@ class OneOf(BaseComposition):
 
         @param output_path: the path in which the resulting video will be stored.
             If not passed in, the original video file will be overwritten
+
+        @param seed: if provided, the random seed will be set to this before calling
+            the transform
+
+        @param metadata: if set to be a list, metadata about the function execution
+            including its name, the source & dest duration, fps, etc. will be appended
+            to the inputted list. If set to None, no metadata will be appended or returned
+
+        @returns: the path to the augmented video
         """
+        video_path, output_path = validate_input_and_output_paths(
+            video_path, output_path
+        )
+
+        if seed is not None:
+            random.seed(seed)
+
         if random.random() > self.p:
-            return None
+            return output_path
 
         transform = random.choices(self.transforms, self.transform_probs)[0]
-        return transform(video_path, output_path, force=True)
+        return transform(video_path, output_path, force=True, metadata=metadata)


### PR DESCRIPTION
Summary: In the process of fixing all modalities to match audio, where Compose can accept a metadata arg. Also added seed arg to Compose (to align with video transforms so the same test function could be run), added a unit test for Compose and removed mentions of un-open sourced augmentations from comments in the composition.py file.

Reviewed By: jbitton

Differential Revision: D29794521

