### PR TITLE
Fix test commands in READMEs & PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -16,7 +16,7 @@ python -m unittest discover -s augly/tests/audio_tests/ -p "*"
 
 ### Image
 ```bash
-python -m unittest discover -s augly/tests/image_tests/ -p "*_tests.py"
+python -m unittest discover -s augly/tests/image_tests/ -p "*_test.py"
 # Or `python -m unittest discover -s augly/tests/image_tests/ -p "*.py"` to run pytorch test too (must install `torchvision` to run)
 ```
 

--- a/augly/image/README.md
+++ b/augly/image/README.md
@@ -1,6 +1,6 @@
 # Image
 
-## Installation   
+## Installation
 If you would like to use the image augmentations, please install AugLy using the following command:
 ```bash
 pip install augly
@@ -79,7 +79,7 @@ np_aug_img = aug_np_wrapper(np_image, overlay_emoji, **{'opacity': 0.5, 'y_pos':
 
 You can run our normal image unit tests if you have cloned `augly` (see [here](../../README.md)) by running the following:
 ```bash
-python -m unittest discover -s augly/tests/image_tests/ -p "*_tests.py"
+python -m unittest discover -s augly/tests/image_tests/ -p "*_test.py"
 ```
 
 Note: If you want to additionally run the pytorch unit test (you must have torchvision installed), you can run:

--- a/augly/video/README.md
+++ b/augly/video/README.md
@@ -89,8 +89,8 @@ python -m unittest discover -s augly/tests/video_tests/ -p "*"
 
 Note: some of the video tests take a while to run (up to a few minutes). If you want to run the 4 test suites individually, you can run any of the following commands (listed in order of increasing runtime):
 ```bash
-python -m unittest augly.tests.video_tests.transforms.composite_tests
-python -m unittest augly.tests.video_tests.transforms.cv2_tests
-python -m unittest augly.tests.video_tests.transforms.ffmpeg_tests
-python -m unittest augly.tests.video_tests.transforms.image_based_tests
+python -m unittest augly.tests.video_tests.transforms.composite_test
+python -m unittest augly.tests.video_tests.transforms.cv2_test
+python -m unittest augly.tests.video_tests.transforms.ffmpeg_test
+python -m unittest augly.tests.video_tests.transforms.image_based_test
 ```


### PR DESCRIPTION
Summary: Some of the test commands were outdated in the READMEs & PR templates, from before we renamed all test files to end in _test.py instead of _tests.py.

Differential Revision: D30281710

