### PR TITLE
[Image] Add a more descriptive error message for caption height invalid values

### DIFF
--- a/augly/image/functional.py
+++ b/augly/image/functional.py
@@ -751,14 +751,14 @@ def meme_format(
 
     @returns: the augmented PIL Image
     """
-    assert type(text) == str, "Expected variable `text` to be a string"
+    assert isinstance(text, str), "Expected variable `text` to be a string"
     assert 0.0 <= opacity <= 1.0, "Opacity must be a value in the range [0.0, 1.0]"
+    assert caption_height > 10, "Your caption height must be greater than 10"
 
     utils.validate_rgb_color(text_color)
     utils.validate_rgb_color(meme_bg_color)
 
     image = imutils.validate_and_load_image(image)
-
     func_kwargs = imutils.get_func_kwargs(metadata, locals())
 
     width, height = image.size

--- a/augly/image/functional.py
+++ b/augly/image/functional.py
@@ -753,7 +753,7 @@ def meme_format(
     """
     assert isinstance(text, str), "Expected variable `text` to be a string"
     assert 0.0 <= opacity <= 1.0, "Opacity must be a value in the range [0.0, 1.0]"
-    assert caption_height > 10, "Your caption height must be greater than 10"
+    assert caption_height > 10, "Caption height must be greater than 10"
 
     utils.validate_rgb_color(text_color)
     utils.validate_rgb_color(meme_bg_color)


### PR DESCRIPTION
## Related Issue
Fixes #96 

## Summary
- [x] I have read CONTRIBUTING.md to understand how to contribute to this repository :)

As discussed in #96, if you have a caption height <= 10, you get a non-descriptive error message which isn't helpful to our users. This PR aims to have a more descriptive error message :)

## Unit Tests

### Image
```bash
python -m unittest augly.tests.image_tests.functional_unit_test
----------------------------------------------------------------------
Ran 36 tests in 38.571s

OK (skipped=2)
```

```bash
python -m unittest augly.tests.image_tests.transforms_unit_test
----------------------------------------------------------------------
Ran 43 tests in 10.437s

OK (skipped=3)
```