### PR TITLE
Update pypi version (with new text fairness augmentations)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open("README.md", encoding="utf8") as f:
 
 setuptools.setup(
     name="augly",
-    version="0.1.6",
+    version="0.1.7",
     description="A data augmentations library for audio, image, text, & video.",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -41,5 +41,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent"
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
Fixes: https://github.com/facebookresearch/AugLy/issues/101

Summary: Will update the version of augly on pypi to 0.1.7, which will include the augmentations we've added recently like the text fairness ones, after exporting this to a GitHub PR. Also fixed `setup.py` to reflect that python 3.6+ is supported, not just 3.7+.

Differential Revision: D30897095

