### PR TITLE
Augment audio to a video

### DIFF
--- a/augly/video/functional.py
+++ b/augly/video/functional.py
@@ -8,13 +8,15 @@ import shutil
 import tempfile
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+import numpy as np
+
+import augly.audio as audaugs
 import augly.image as imaugs
 import augly.utils as utils
 import augly.video.augmenters.cv2 as ac
 import augly.video.augmenters.ffmpeg as af
 import augly.video.helpers as helpers
 import augly.video.utils as vdutils
-import numpy as np
 
 
 def add_noise(
@@ -229,7 +231,8 @@ def blur(
     vdutils.apply_ffmpeg_augmenter(blur_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="blur", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="blur", **func_kwargs)
 
     return output_path or video_path
 
@@ -466,7 +469,8 @@ def contrast(
     vdutils.apply_ffmpeg_augmenter(contrast_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="contrast", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="contrast", **func_kwargs)
 
     return output_path or video_path
 
@@ -512,7 +516,8 @@ def crop(
     vdutils.apply_ffmpeg_augmenter(crop_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="crop", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="crop", **func_kwargs)
 
     return output_path or video_path
 
@@ -583,7 +588,8 @@ def fps(
     vdutils.apply_ffmpeg_augmenter(fps_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="fps", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="fps", **func_kwargs)
 
     return output_path or video_path
 
@@ -645,7 +651,8 @@ def hflip(
     vdutils.apply_ffmpeg_augmenter(hflip_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="hflip", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="hflip", **func_kwargs)
 
     return output_path or video_path
 
@@ -678,11 +685,13 @@ def hstack(
     """
     func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
 
-    hstack_aug = af.VideoAugmenterByStack(second_video_path, use_second_audio, "hstack")
+    hstack_aug = af.VideoAugmenterByStack(
+        second_video_path, use_second_audio, "hstack")
     vdutils.apply_ffmpeg_augmenter(hstack_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="hstack", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="hstack", **func_kwargs)
 
     return output_path or video_path
 
@@ -754,7 +763,8 @@ def insert_in_background(
         helpers.add_silent_audio(video_path, tmp_video_path)
 
         if background_path is None:
-            helpers.create_color_video(resized_bg_path, video_duration, height, width)
+            helpers.create_color_video(
+                resized_bg_path, video_duration, height, width)
         else:
             resize(background_path, resized_bg_path, height, width)
             helpers.add_silent_audio(resized_bg_path)
@@ -771,10 +781,11 @@ def insert_in_background(
             desired_bg_duration = video_duration / source_percentage - video_duration
 
             # if background vid isn't long enough, loop
-            num_loops_needed = math.ceil(desired_bg_duration / bg_video_duration)
+            num_loops_needed = math.ceil(
+                desired_bg_duration / bg_video_duration)
             if num_loops_needed > 1:
                 loop(resized_bg_path, num_loops=num_loops_needed)
-                bg_video_duration*=num_loops_needed
+                bg_video_duration *= num_loops_needed
 
             bg_start = rng.uniform(0, bg_video_duration - desired_bg_duration)
             bg_end = bg_start + desired_bg_duration
@@ -783,7 +794,8 @@ def insert_in_background(
 
         if offset > 0:
             before_path = os.path.join(tmpdir, "before.mp4")
-            trim(resized_bg_path, before_path, start=bg_start, end=bg_start + offset)
+            trim(resized_bg_path, before_path,
+                 start=bg_start, end=bg_start + offset)
             video_paths.append(before_path)
             src_video_path_index = 1
         else:
@@ -877,7 +889,8 @@ def replace_with_background(
 
         # create bg video
         if background_path is None:
-            helpers.create_color_video(resized_bg_path, video_duration, height, width)
+            helpers.create_color_video(
+                resized_bg_path, video_duration, height, width)
         else:
             resize(background_path, resized_bg_path, height, width)
             helpers.add_silent_audio(resized_bg_path)
@@ -975,7 +988,8 @@ def loop(
     vdutils.apply_ffmpeg_augmenter(loop_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="loop", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="loop", **func_kwargs)
 
     return output_path or video_path
 
@@ -1091,7 +1105,8 @@ def overlay(
         overlay_h = int(video_info["height"] * overlay_size)
         overlay_w = int(video_info["width"] * overlay_size)
 
-        _, tmp_overlay_path = tempfile.mkstemp(suffix=os.path.splitext(overlay_path)[1])
+        _, tmp_overlay_path = tempfile.mkstemp(
+            suffix=os.path.splitext(overlay_path)[1])
 
         if utils.is_image_file(overlay_path):
             imaugs.resize(overlay_path, tmp_overlay_path, overlay_w, overlay_h)
@@ -1107,7 +1122,8 @@ def overlay(
         os.remove(tmp_overlay_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="overlay", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="overlay", **func_kwargs)
 
     return output_path or video_path
 
@@ -1197,7 +1213,8 @@ def overlay_emoji(
     video_info = helpers.get_video_info(video_path)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        local_emoji_path = utils.pathmgr.get_local_path(emoji_path, cache_dir=tmpdir)
+        local_emoji_path = utils.pathmgr.get_local_path(
+            emoji_path, cache_dir=tmpdir)
         utils.validate_image_path(local_emoji_path)
 
         emoji_output_path = os.path.join(tmpdir, "modified_emoji.png")
@@ -1208,7 +1225,8 @@ def overlay_emoji(
             height=int(emoji_size * video_info["height"]),
             width=int(emoji_size * video_info["height"]),
         )
-        imaugs.opacity(emoji_output_path, output_path=emoji_output_path, level=opacity)
+        imaugs.opacity(emoji_output_path,
+                       output_path=emoji_output_path, level=opacity)
 
         overlay(
             video_path,
@@ -1524,7 +1542,8 @@ def pad(
     vdutils.apply_ffmpeg_augmenter(pad_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="pad", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="pad", **func_kwargs)
 
     return output_path or video_path
 
@@ -1579,7 +1598,8 @@ def perspective_transform_and_shake(
             "dy": u * rng.normal(0, shake_radius),
         }
 
-    vdutils.apply_to_each_frame(perspective_func, video_path, output_path, get_dx_dy)
+    vdutils.apply_to_each_frame(
+        perspective_func, video_path, output_path, get_dx_dy)
 
     if metadata is not None:
         helpers.get_metadata(
@@ -1726,7 +1746,8 @@ def replace_with_color_frames(
             video_duration - offset if offset + duration >= video_duration else duration
         )
         color_path = os.path.join(tmpdir, "color_frames.mp4")
-        helpers.create_color_video(color_path, color_duration, height, width, color)
+        helpers.create_color_video(
+            color_path, color_duration, height, width, color)
 
         if helpers.has_audio_stream(video_path):
             audio_path = os.path.join(tmpdir, "audio.aac")
@@ -1751,7 +1772,8 @@ def replace_with_color_frames(
             trim(video_path, after_path, start=offset + duration)
             video_paths.append(after_path)
 
-        concat(video_paths, output_path, src_video_path_index=src_video_path_index)
+        concat(video_paths, output_path,
+               src_video_path_index=src_video_path_index)
 
     if metadata is not None:
         helpers.get_metadata(metadata=metadata, **func_kwargs)
@@ -1792,7 +1814,8 @@ def resize(
     vdutils.apply_ffmpeg_augmenter(resize_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="resize", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="resize", **func_kwargs)
 
     return output_path or video_path
 
@@ -1826,7 +1849,8 @@ def rotate(
     vdutils.apply_ffmpeg_augmenter(rotate_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="rotate", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="rotate", **func_kwargs)
 
     return output_path or video_path
 
@@ -1859,7 +1883,8 @@ def scale(
     vdutils.apply_ffmpeg_augmenter(scale_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="scale", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="scale", **func_kwargs)
 
     return output_path or video_path
 
@@ -1921,7 +1946,8 @@ def shift(
         )
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="shift", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="shift", **func_kwargs)
 
     return output_path or video_path
 
@@ -2067,7 +2093,8 @@ def trim(
     vdutils.apply_ffmpeg_augmenter(trim_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="trim", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="trim", **func_kwargs)
 
     return output_path or video_path
 
@@ -2097,7 +2124,8 @@ def vflip(
     vdutils.apply_ffmpeg_augmenter(vflip_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="vflip", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="vflip", **func_kwargs)
 
     return output_path or video_path
 
@@ -2130,10 +2158,68 @@ def vstack(
     """
     func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
 
-    vstack_aug = af.VideoAugmenterByStack(second_video_path, use_second_audio, "vstack")
+    vstack_aug = af.VideoAugmenterByStack(
+        second_video_path, use_second_audio, "vstack")
     vdutils.apply_ffmpeg_augmenter(vstack_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(metadata=metadata, function_name="vstack", **func_kwargs)
+        helpers.get_metadata(
+            metadata=metadata, function_name="vstack", **func_kwargs)
 
+    return output_path or video_path
+
+
+def augment_audio(
+    video_path: str,
+    audio_aug_function: Callable[...,
+                                 Tuple[np.ndarray, int]] = audaugs.apply_lambda,
+    output_path: Optional[str] = None,
+    metadata: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """
+    Augments audio into a video
+
+    @param video_path: the path to the video to be augmented
+
+    @param audio_aug_function: the augmentation function to be applied onto the video
+        (should expect a video path and output path as input and output the augmented
+        video to the output path. Nothing needs to be returned) THIS NEEDS TO BE CHANGED
+
+    @param output_path: the path in which the resulting video will be stored.
+        If not passed in, the original video file will be overwritten
+
+    @param metadata: if set to be a list, metadata about the function execution
+        including its name, the source & dest duration, fps, etc. will be appended
+        to the inputted list. If set to None, no metadata will be appended or returned
+
+    @returns: the path to the augmented video
+    """
+    assert callable(audio_aug_function), (
+        repr(type(audio_aug_function).__name__) + " object is not callable"
+    )
+
+    func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
+
+    audio_metadata: Optional[List[Dict[str, Any]]] = None
+
+    # extract the audio
+    with tempfile.NamedTemporaryFile(suffix=".aac") as tmpfile:
+        helpers.extract_audio_to_file(video_path, tmpfile.name)
+        # will overwrite the current temporary audio file with the augmented one
+        audio_aug_function(tmpfile.name)
+        # put back the augmented audio
+        audio_swap(video_path, tmpfile.name)
+        if metadata is not None:
+            helpers.get_metadata(
+                metadata=audio_metadata, function_name="augment_audio", **func_kwargs
+            )
+
+    if metadata is not None:
+        helpers.get_metadata(
+            metadata=metadata,
+            audio_metadata=audio_metadata,
+            function_name="augment_audio",
+            **func_kwargs,
+        )
+    # test in composite_tests.py
     return output_path or video_path

--- a/augly/video/functional.py
+++ b/augly/video/functional.py
@@ -231,8 +231,7 @@ def blur(
     vdutils.apply_ffmpeg_augmenter(blur_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="blur", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="blur", **func_kwargs)
 
     return output_path or video_path
 
@@ -469,8 +468,7 @@ def contrast(
     vdutils.apply_ffmpeg_augmenter(contrast_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="contrast", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="contrast", **func_kwargs)
 
     return output_path or video_path
 
@@ -516,8 +514,7 @@ def crop(
     vdutils.apply_ffmpeg_augmenter(crop_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="crop", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="crop", **func_kwargs)
 
     return output_path or video_path
 
@@ -588,8 +585,7 @@ def fps(
     vdutils.apply_ffmpeg_augmenter(fps_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="fps", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="fps", **func_kwargs)
 
     return output_path or video_path
 
@@ -651,8 +647,7 @@ def hflip(
     vdutils.apply_ffmpeg_augmenter(hflip_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="hflip", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="hflip", **func_kwargs)
 
     return output_path or video_path
 
@@ -685,13 +680,11 @@ def hstack(
     """
     func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
 
-    hstack_aug = af.VideoAugmenterByStack(
-        second_video_path, use_second_audio, "hstack")
+    hstack_aug = af.VideoAugmenterByStack(second_video_path, use_second_audio, "hstack")
     vdutils.apply_ffmpeg_augmenter(hstack_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="hstack", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="hstack", **func_kwargs)
 
     return output_path or video_path
 
@@ -763,8 +756,7 @@ def insert_in_background(
         helpers.add_silent_audio(video_path, tmp_video_path)
 
         if background_path is None:
-            helpers.create_color_video(
-                resized_bg_path, video_duration, height, width)
+            helpers.create_color_video(resized_bg_path, video_duration, height, width)
         else:
             resize(background_path, resized_bg_path, height, width)
             helpers.add_silent_audio(resized_bg_path)
@@ -781,8 +773,7 @@ def insert_in_background(
             desired_bg_duration = video_duration / source_percentage - video_duration
 
             # if background vid isn't long enough, loop
-            num_loops_needed = math.ceil(
-                desired_bg_duration / bg_video_duration)
+            num_loops_needed = math.ceil(desired_bg_duration / bg_video_duration)
             if num_loops_needed > 1:
                 loop(resized_bg_path, num_loops=num_loops_needed)
                 bg_video_duration *= num_loops_needed
@@ -794,8 +785,7 @@ def insert_in_background(
 
         if offset > 0:
             before_path = os.path.join(tmpdir, "before.mp4")
-            trim(resized_bg_path, before_path,
-                 start=bg_start, end=bg_start + offset)
+            trim(resized_bg_path, before_path, start=bg_start, end=bg_start + offset)
             video_paths.append(before_path)
             src_video_path_index = 1
         else:
@@ -889,8 +879,7 @@ def replace_with_background(
 
         # create bg video
         if background_path is None:
-            helpers.create_color_video(
-                resized_bg_path, video_duration, height, width)
+            helpers.create_color_video(resized_bg_path, video_duration, height, width)
         else:
             resize(background_path, resized_bg_path, height, width)
             helpers.add_silent_audio(resized_bg_path)
@@ -988,8 +977,7 @@ def loop(
     vdutils.apply_ffmpeg_augmenter(loop_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="loop", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="loop", **func_kwargs)
 
     return output_path or video_path
 
@@ -1105,8 +1093,7 @@ def overlay(
         overlay_h = int(video_info["height"] * overlay_size)
         overlay_w = int(video_info["width"] * overlay_size)
 
-        _, tmp_overlay_path = tempfile.mkstemp(
-            suffix=os.path.splitext(overlay_path)[1])
+        _, tmp_overlay_path = tempfile.mkstemp(suffix=os.path.splitext(overlay_path)[1])
 
         if utils.is_image_file(overlay_path):
             imaugs.resize(overlay_path, tmp_overlay_path, overlay_w, overlay_h)
@@ -1122,8 +1109,7 @@ def overlay(
         os.remove(tmp_overlay_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="overlay", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="overlay", **func_kwargs)
 
     return output_path or video_path
 
@@ -1213,8 +1199,7 @@ def overlay_emoji(
     video_info = helpers.get_video_info(video_path)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        local_emoji_path = utils.pathmgr.get_local_path(
-            emoji_path, cache_dir=tmpdir)
+        local_emoji_path = utils.pathmgr.get_local_path(emoji_path, cache_dir=tmpdir)
         utils.validate_image_path(local_emoji_path)
 
         emoji_output_path = os.path.join(tmpdir, "modified_emoji.png")
@@ -1225,8 +1210,7 @@ def overlay_emoji(
             height=int(emoji_size * video_info["height"]),
             width=int(emoji_size * video_info["height"]),
         )
-        imaugs.opacity(emoji_output_path,
-                       output_path=emoji_output_path, level=opacity)
+        imaugs.opacity(emoji_output_path, output_path=emoji_output_path, level=opacity)
 
         overlay(
             video_path,
@@ -1542,8 +1526,7 @@ def pad(
     vdutils.apply_ffmpeg_augmenter(pad_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="pad", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="pad", **func_kwargs)
 
     return output_path or video_path
 
@@ -1598,8 +1581,7 @@ def perspective_transform_and_shake(
             "dy": u * rng.normal(0, shake_radius),
         }
 
-    vdutils.apply_to_each_frame(
-        perspective_func, video_path, output_path, get_dx_dy)
+    vdutils.apply_to_each_frame(perspective_func, video_path, output_path, get_dx_dy)
 
     if metadata is not None:
         helpers.get_metadata(
@@ -1746,8 +1728,7 @@ def replace_with_color_frames(
             video_duration - offset if offset + duration >= video_duration else duration
         )
         color_path = os.path.join(tmpdir, "color_frames.mp4")
-        helpers.create_color_video(
-            color_path, color_duration, height, width, color)
+        helpers.create_color_video(color_path, color_duration, height, width, color)
 
         if helpers.has_audio_stream(video_path):
             audio_path = os.path.join(tmpdir, "audio.aac")
@@ -1772,8 +1753,7 @@ def replace_with_color_frames(
             trim(video_path, after_path, start=offset + duration)
             video_paths.append(after_path)
 
-        concat(video_paths, output_path,
-               src_video_path_index=src_video_path_index)
+        concat(video_paths, output_path, src_video_path_index=src_video_path_index)
 
     if metadata is not None:
         helpers.get_metadata(metadata=metadata, **func_kwargs)
@@ -1814,8 +1794,7 @@ def resize(
     vdutils.apply_ffmpeg_augmenter(resize_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="resize", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="resize", **func_kwargs)
 
     return output_path or video_path
 
@@ -1849,8 +1828,7 @@ def rotate(
     vdutils.apply_ffmpeg_augmenter(rotate_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="rotate", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="rotate", **func_kwargs)
 
     return output_path or video_path
 
@@ -1883,8 +1861,7 @@ def scale(
     vdutils.apply_ffmpeg_augmenter(scale_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="scale", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="scale", **func_kwargs)
 
     return output_path or video_path
 
@@ -1946,8 +1923,7 @@ def shift(
         )
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="shift", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="shift", **func_kwargs)
 
     return output_path or video_path
 
@@ -2093,8 +2069,7 @@ def trim(
     vdutils.apply_ffmpeg_augmenter(trim_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="trim", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="trim", **func_kwargs)
 
     return output_path or video_path
 
@@ -2124,8 +2099,7 @@ def vflip(
     vdutils.apply_ffmpeg_augmenter(vflip_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="vflip", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="vflip", **func_kwargs)
 
     return output_path or video_path
 
@@ -2158,21 +2132,18 @@ def vstack(
     """
     func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
 
-    vstack_aug = af.VideoAugmenterByStack(
-        second_video_path, use_second_audio, "vstack")
+    vstack_aug = af.VideoAugmenterByStack(second_video_path, use_second_audio, "vstack")
     vdutils.apply_ffmpeg_augmenter(vstack_aug, video_path, output_path)
 
     if metadata is not None:
-        helpers.get_metadata(
-            metadata=metadata, function_name="vstack", **func_kwargs)
+        helpers.get_metadata(metadata=metadata, function_name="vstack", **func_kwargs)
 
     return output_path or video_path
 
 
 def augment_audio(
     video_path: str,
-    audio_aug_function: Callable[...,
-                                 Tuple[np.ndarray, int]] = audaugs.apply_lambda,
+    audio_aug_function: Callable[..., Tuple[np.ndarray, int]] = audaugs.apply_lambda,
     output_path: Optional[str] = None,
     metadata: Optional[List[Dict[str, Any]]] = None,
 ) -> str:


### PR DESCRIPTION
## Related Issue
Fixes #130 

## Summary
- [X] I have read CONTRIBUTING.md to understand how to contribute to this repository :)

<Please summarize what you are trying to achieve, what changes you made, and how they acheive the desired result.>

I'm trying to extract the audio to a temporary file and then apply some audio augmentation. After that I swap the current audio in the video with the augmented audio. I also gather metadata for the augmented audio and video. It either returns the output path (if it was specified) or the video path.

Only file that was changed was `/AugLy/augly/video/functional.py`. A question I have is what should be the description for the `audio_aug_function` param?


## Unit Tests
If your changes touch the `audio` module, please run all of the `audio` tests and paste the output here. Likewise for `image`, `text`, & `video`. If your changes could affect behavior in multiple modules, please run the tests for all potentially affected modules. If you are unsure of which modules might be affected by your changes, please just run all the unit tests.

### Video
```bash
python -m unittest discover -s augly/tests/video_tests/ -p "*"
```

Output of test suite for video
```
...../Users/admin/AugLy/augly/image/utils/utils.py:51: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/admin/AugLy/augly/assets/screenshot_templates/bboxes.json'>
  bbox = json.load(open(local_bbox_path, "rb"))[template_key]
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/admin/AugLy/augly/video/helpers/metadata.py:357: ResourceWarning: unclosed file <_io.BufferedReader name='/Users/admin/AugLy/augly/assets/screenshot_templates/web.png'>
  metadata[-1]["intensity"] = getattr(
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/admin/AugLy/augly/image/utils/utils.py:184: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  A = np.matrix(matrix, dtype=np.float)
/Users/admin/AugLy/augly/image/utils/utils.py:184: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  A = np.matrix(matrix, dtype=np.float)
/Users/admin/opt/anaconda3/envs/augly/lib/python3.9/site-packages/numpy/matrixlib/defmatrix.py:69: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
  return matrix(data, dtype=dtype, copy=False)
..
======================================================================
FAIL: test_ReplaceWithBackground (transforms.composite_test.TransformsVideoUnitTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/admin/AugLy/augly/tests/video_tests/transforms/composite_test.py", line 75, in test_ReplaceWithBackground
    self.evaluate_class(
  File "/Users/admin/AugLy/augly/tests/video_tests/base_unit_test.py", line 122, in evaluate_class
    self.assertTrue(
AssertionError: False is not true

----------------------------------------------------------------------
Ran 63 tests in 813.840s

FAILED (failures=1)
```

## Other testing
N/A only looking for some feedback on the work I did so far

If applicable, test your changes and paste the output here. For example, if your changes affect the requirements/installation, then test installing augly in a fresh conda env, then make sure you are able to import augly & run the unit test
