### PR TITLE
`black` formatting

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-python@v2
       - run: pip install bandit black codespell flake8 isort pyre-check pytest pyupgrade safety
       - run: bandit --recursive --skip B101,B301,B303,B311,B403 .
-      - run: black --check . || true
+      - run: black --check .
       - run: codespell --ignore-words-list="tha" --skip="*/text_tests,*assets/text/*"
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: flake8 . --count --exit-zero --max-complexity=15 --max-line-length=90 --show-source --statistics

--- a/augly/audio/utils.py
+++ b/augly/audio/utils.py
@@ -13,8 +13,8 @@ from augly.utils.libsndfile import install_libsndfile
 
 install_libsndfile()
 import librosa
-import torchaudio
 import soundfile as sf
+import torchaudio
 
 # Use Any because np.random.Generator is not a valid type for pyre
 RNG = Any

--- a/augly/image/functional.py
+++ b/augly/image/functional.py
@@ -115,8 +115,8 @@ def apply_pil_filter(
     func_kwargs = deepcopy(locals())
 
     ftr = filter_type() if isinstance(filter_type, Callable) else filter_type
-    assert (
-        isinstance(ftr, ImageFilter.Filter)
+    assert isinstance(
+        ftr, ImageFilter.Filter
     ), "Filter type must be a PIL.ImageFilter.Filter class"
 
     func_kwargs = imutils.get_func_kwargs(
@@ -224,9 +224,7 @@ def brightness(
     aug_image = ImageEnhance.Brightness(image).enhance(factor)
 
     func_kwargs = imutils.get_func_kwargs(metadata, locals())
-    imutils.get_metadata(
-        metadata=metadata, function_name="brightness", **func_kwargs
-    )
+    imutils.get_metadata(metadata=metadata, function_name="brightness", **func_kwargs)
 
     return imutils.ret_and_save_image(aug_image, output_path)
 
@@ -410,9 +408,7 @@ def color_jitter(
     aug_image = ImageEnhance.Color(aug_image).enhance(saturation_factor)
 
     func_kwargs = imutils.get_func_kwargs(metadata, locals())
-    imutils.get_metadata(
-        metadata=metadata, function_name="color_jitter", **func_kwargs
-    )
+    imutils.get_metadata(metadata=metadata, function_name="color_jitter", **func_kwargs)
 
     return imutils.ret_and_save_image(aug_image, output_path)
 
@@ -544,7 +540,9 @@ def convert_color(
 
     func_kwargs = imutils.get_func_kwargs(metadata, locals())
     imutils.get_metadata(
-        metadata=metadata, function_name="convert_color", **func_kwargs,
+        metadata=metadata,
+        function_name="convert_color",
+        **func_kwargs,
     )
 
     return imutils.ret_and_save_image(aug_image, output_path)
@@ -774,9 +772,7 @@ def hflip(
     aug_image = image.transpose(Image.FLIP_LEFT_RIGHT)
 
     func_kwargs = imutils.get_func_kwargs(metadata, locals())
-    imutils.get_metadata(
-        metadata=metadata, function_name="hflip", **func_kwargs
-    )
+    imutils.get_metadata(metadata=metadata, function_name="hflip", **func_kwargs)
 
     return imutils.ret_and_save_image(aug_image, output_path)
 
@@ -1407,12 +1403,18 @@ def overlay_stripes(
 
     @returns: the augmented PIL Image
     """
-    assert 0.0 <= line_width <= 1.0, "Line width must be a value in the range [0.0, 1.0]"
+    assert (
+        0.0 <= line_width <= 1.0
+    ), "Line width must be a value in the range [0.0, 1.0]"
     assert (
         -360.0 <= line_angle <= 360.0
     ), "Line angle must be a degree in the range [360.0, 360.0]"
-    assert 0.0 <= line_density <= 1.0, "Line density must be a value in the range [0.0, 1.0]"
-    assert 0.0 <= line_opacity <= 1.0, "Line opacity must be a value in the range [0.0, 1.0]"
+    assert (
+        0.0 <= line_density <= 1.0
+    ), "Line density must be a value in the range [0.0, 1.0]"
+    assert (
+        0.0 <= line_opacity <= 1.0
+    ), "Line opacity must be a value in the range [0.0, 1.0]"
     assert line_type in utils.SUPPORTED_LINE_TYPES, "Stripe type not supported"
     utils.validate_rgb_color(line_color)
 
@@ -1533,15 +1535,12 @@ def overlay_text(
     func_kwargs = imutils.get_func_kwargs(metadata, locals())
 
     text_lists = text if all(isinstance(t, list) for t in text) else [text]
-    assert (
-        all(isinstance(t, list) for t in text_lists)
-        and all(
-            all(isinstance(t, int) for t in text_l)  # pyre-ignore text_l is a List[int]
-            for text_l in text_lists
-        )
+    assert all(isinstance(t, list) for t in text_lists) and all(
+        all(isinstance(t, int) for t in text_l)  # pyre-ignore text_l is a List[int]
+        for text_l in text_lists
     ), "Text must be a list of ints or a list of list of ints for multiple lines"
 
-    image = image.convert('RGBA')
+    image = image.convert("RGBA")
     width, height = image.size
 
     local_font_path = utils.pathmgr.get_local_path(font_file)
@@ -1555,9 +1554,9 @@ def overlay_text(
         chars = pickle.load(f)
 
     try:
-        text_strs = (
-            ["".join([chr(chars[c % len(chars)]) for c in t]) for t in text_lists]
-        )
+        text_strs = [
+            "".join([chr(chars[c % len(chars)]) for c in t]) for t in text_lists
+        ]
     except Exception:
         raise IndexError("Invalid text indices specified")
 

--- a/augly/image/intensity.py
+++ b/augly/image/intensity.py
@@ -129,12 +129,16 @@ def masked_composite_intensity(
         mask_intensity = np.sum(mask_values > 0) / (
             mask_values.shape[0] * mask_values.shape[1]
         )
-    if metadata['transform_function'] is None:
+    if metadata["transform_function"] is None:
         aug_intensity = 0.0
     else:
-        aug_intensity_func = globals().get(f"{metadata['transform_function']}_intensity")
+        aug_intensity_func = globals().get(
+            f"{metadata['transform_function']}_intensity"
+        )
         aug_intensity = (
-            aug_intensity_func(**kwargs) / 100.0 if aug_intensity_func is not None else 1.0
+            aug_intensity_func(**kwargs) / 100.0
+            if aug_intensity_func is not None
+            else 1.0
         )
     return (aug_intensity * mask_intensity) * 100.0
 
@@ -151,15 +155,11 @@ def opacity_intensity(level: float, **kwargs) -> float:
     return (1 - level) * 100.0
 
 
-def overlay_emoji_intensity(
-    emoji_size: float, opacity: float, **kwargs
-) -> float:
+def overlay_emoji_intensity(emoji_size: float, opacity: float, **kwargs) -> float:
     return overlay_media_intensity_helper(opacity, emoji_size)
 
 
-def overlay_image_intensity(
-    opacity: float, overlay_size: float, **kwargs
-) -> float:
+def overlay_image_intensity(opacity: float, overlay_size: float, **kwargs) -> float:
     return overlay_media_intensity_helper(opacity, overlay_size)
 
 
@@ -175,9 +175,7 @@ def overlay_onto_screenshot_intensity(
     metadata: Dict[str, Any],
     **kwargs,
 ) -> float:
-    _, bbox = imutils.get_template_and_bbox(
-        template_filepath, template_bboxes_filepath
-    )
+    _, bbox = imutils.get_template_and_bbox(template_filepath, template_bboxes_filepath)
     bbox_area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
     dst_area = metadata["dst_width"] * metadata["dst_height"]
     return min(((dst_area - bbox_area) / dst_area) * 100.0, 100.0)
@@ -190,7 +188,8 @@ def overlay_stripes_intensity(
     line_type: str,
     line_opacity: float,
     metadata: Dict[str, Any],
-    **kwargs) -> float:
+    **kwargs,
+) -> float:
     binary_mask = imutils.compute_stripe_mask(
         src_w=metadata["src_width"],
         src_h=metadata["src_height"],

--- a/augly/image/transforms.py
+++ b/augly/image/transforms.py
@@ -212,7 +212,9 @@ class ApplyLambda(BaseTransform):
 class ApplyPILFilter(BaseTransform):
     def __init__(
         self,
-        filter_type: Union[Callable, ImageFilter.Filter] = ImageFilter.EDGE_ENHANCE_MORE,
+        filter_type: Union[
+            Callable, ImageFilter.Filter
+        ] = ImageFilter.EDGE_ENHANCE_MORE,
         p: float = 1.0,
     ):
         """
@@ -561,7 +563,8 @@ class Contrast(BaseTransform):
             factor=self.factor,
             metadata=metadata,
             bboxes=bboxes,
-            bbox_format=bbox_format)
+            bbox_format=bbox_format,
+        )
 
 
 class ConvertColor(BaseTransform):
@@ -1336,7 +1339,7 @@ class OverlayStripes(BaseTransform):
         line_density: float = 0.5,
         line_type: Optional[str] = "solid",
         line_opacity: float = 1.0,
-        p: float = 1.0
+        p: float = 1.0,
     ):
         """
         @param line_width: the width of individual stripes as a float value ranging
@@ -1401,7 +1404,7 @@ class OverlayStripes(BaseTransform):
             line_opacity=self.line_opacity,
             metadata=metadata,
             bboxes=bboxes,
-            bbox_format=bbox_format
+            bbox_format=bbox_format,
         )
 
 

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -2,10 +2,10 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
-import numpy as np
 from typing import List, Optional, Tuple
 
 import augly.image.utils as imutils
+import numpy as np
 
 
 def crop_bboxes_helper(
@@ -145,7 +145,12 @@ def overlay_onto_screenshot_bboxes_helper(
         src_scale_factor = min(tbbox_w / src_w, tbbox_h / src_h)
     else:
         template, tbbox = imutils.scale_template_image(
-            src_w, src_h, template, tbbox, max_image_size_pixels, crop_src_to_fit,
+            src_w,
+            src_h,
+            template,
+            tbbox,
+            max_image_size_pixels,
+            crop_src_to_fit,
         )
         tbbox_w, tbbox_h = tbbox[2] - tbbox[0], tbbox[3] - tbbox[1]
         src_scale_factor = 1
@@ -156,7 +161,10 @@ def overlay_onto_screenshot_bboxes_helper(
     # Src image is scaled (if resize_src_to_match_template)
     curr_w, curr_h = src_w * src_scale_factor, src_h * src_scale_factor
     left, upper, right, lower = (
-        left_f * curr_w, upper_f * curr_h, right_f * curr_w, lower_f * curr_h
+        left_f * curr_w,
+        upper_f * curr_h,
+        right_f * curr_w,
+        lower_f * curr_h,
     )
 
     # Src image is cropped to (tbbox_w, tbbox_h)
@@ -167,13 +175,19 @@ def overlay_onto_screenshot_bboxes_helper(
             bbox, x1 / curr_w, y1 / curr_h, x2 / curr_w, y2 / curr_h
         )
         left, upper, right, lower = (
-            left_f * tbbox_w, upper_f * tbbox_h, right_f * tbbox_w, lower_f * tbbox_h
+            left_f * tbbox_w,
+            upper_f * tbbox_h,
+            right_f * tbbox_w,
+            lower_f * tbbox_h,
         )
     # Src image is resized to (tbbox_w, tbbox_h)
     else:
         resize_f = min(tbbox_w / curr_w, tbbox_h / curr_h)
         left, upper, right, lower = (
-            left * resize_f, upper * resize_f, right * resize_f, lower * resize_f
+            left * resize_f,
+            upper * resize_f,
+            right * resize_f,
+            lower * resize_f,
         )
         curr_w, curr_h = curr_w * resize_f, curr_h * resize_f
 
@@ -181,11 +195,19 @@ def overlay_onto_screenshot_bboxes_helper(
         padding_x = max(0, (tbbox_w - curr_w) // 2)
         padding_y = max(0, (tbbox_h - curr_h) // 2)
         left, upper, right, lower = (
-            left + padding_x, upper + padding_y, right + padding_x, lower + padding_y
+            left + padding_x,
+            upper + padding_y,
+            right + padding_x,
+            lower + padding_y,
         )
 
     # Src image is overlaid onto template image
-    left, upper, right, lower = left + x_off, upper + y_off, right + x_off, lower + y_off
+    left, upper, right, lower = (
+        left + x_off,
+        upper + y_off,
+        right + x_off,
+        lower + y_off,
+    )
 
     return left / template_w, upper / template_h, right / template_w, lower / template_h
 
@@ -291,12 +313,16 @@ def perspective_transform_bboxes_helper(
 
     left_f, upper_f, right_f, lower_f = bbox
     left, upper, right, lower = (
-        left_f * src_w, upper_f * src_h, right_f * src_w, lower_f * src_h
+        left_f * src_w,
+        upper_f * src_h,
+        right_f * src_w,
+        lower_f * src_h,
     )
     bbox_coords = [(left, upper), (right, upper), (right, lower), (left, lower)]
 
     transformed_bbox_coords = [
-        transform(x + 0.5, y + 0.5, perspective_transform_coeffs) for x, y in bbox_coords
+        transform(x + 0.5, y + 0.5, perspective_transform_coeffs)
+        for x, y in bbox_coords
     ]
 
     transformed_xs, transformed_ys = zip(*transformed_bbox_coords)
@@ -338,7 +364,10 @@ def rotate_bboxes_helper(
     """
     left_f, upper_f, right_f, lower_f = bbox
     left, upper, right, lower = (
-        left_f * src_w, upper_f * src_h, right_f * src_w, lower_f * src_h
+        left_f * src_w,
+        upper_f * src_h,
+        right_f * src_w,
+        lower_f * src_h,
     )
     # Top left, upper right, lower right, & lower left corner coefficients (in pixels)
     bbox_corners = [(left, upper), (right, upper), (right, lower), (left, lower)]
@@ -378,9 +407,12 @@ def rotate_bboxes_helper(
 
     # Get rotated image dimensions
     src_img_corners = [(0, 0), (src_w, 0), (src_w, src_h), (0, src_h)]
-    rotated_img_min_x, rotated_img_min_y, rotated_img_max_x, rotated_img_max_y = (
-        get_enclosing_bbox(src_img_corners, rotation_matrix)
-    )
+    (
+        rotated_img_min_x,
+        rotated_img_min_y,
+        rotated_img_max_x,
+        rotated_img_max_y,
+    ) = get_enclosing_bbox(src_img_corners, rotation_matrix)
     rotated_img_w = rotated_img_max_x - rotated_img_min_x
     rotated_img_h = rotated_img_max_y - rotated_img_min_y
 

--- a/augly/image/utils/metadata.py
+++ b/augly/image/utils/metadata.py
@@ -33,8 +33,8 @@ def validate_and_normalize_bboxes(
 ) -> List[Tuple]:
     norm_bboxes = []
     for bbox in bboxes:
-        assert (
-            len(bbox) == 4 and all(isinstance(x, (float, int)) for x in bbox)
+        assert len(bbox) == 4 and all(
+            isinstance(x, (float, int)) for x in bbox
         ), f"Bounding boxes must be tuples of 4 floats; {bbox} is invalid"
 
         norm_bboxes.append(normalize_bbox(bbox, bbox_format, src_w, src_h))
@@ -112,10 +112,12 @@ def transform_bboxes(
     if dst_bboxes is None:
         return
 
-    assert (
-        bbox_format is not None
-        and bbox_format in ["pascal_voc", "pascal_voc_norm", "coco", "yolo"]
-    ), "bbox_format must be specified if bboxes are passed in and must be a supported format"
+    assert bbox_format is not None and bbox_format in [
+        "pascal_voc",
+        "pascal_voc_norm",
+        "coco",
+        "yolo",
+    ], "bbox_format must be specified if bboxes are passed in and must be a supported format"
 
     src_w, src_h = image.size
     aug_w, aug_h = aug_image.size

--- a/augly/tests/audio_tests/base_unit_test.py
+++ b/augly/tests/audio_tests/base_unit_test.py
@@ -57,9 +57,7 @@ class BaseAudioUnitTest(unittest.TestCase):
 
             with tempfile.NamedTemporaryFile(suffix=".wav") as tmpfile:
                 np.random.seed(1)
-                aug_function(
-                    local_audio_path, output_path=tmpfile.name, **kwargs
-                )
+                aug_function(local_audio_path, output_path=tmpfile.name, **kwargs)
                 dst = librosa.load(tmpfile.name, sr=None, mono=False)[0]
 
             self.assertTrue(are_equal_audios(dst, ref))

--- a/augly/tests/audio_tests/transforms_unit_test.py
+++ b/augly/tests/audio_tests/transforms_unit_test.py
@@ -5,9 +5,8 @@ import json
 import random
 import unittest
 
-import numpy as np
-
 import augly.audio as audaugs
+import numpy as np
 from augly.tests.audio_tests.base_unit_test import BaseAudioUnitTest
 from augly.utils import AUDIO_METADATA_PATH
 
@@ -58,7 +57,9 @@ class TransformsAudioUnitTest(BaseAudioUnitTest):
         self.evaluate_class(
             audaugs.Compose(
                 [
-                    audaugs.InsertInBackground(offset_factor=0.2, background_audio=None, seed=random_generator),
+                    audaugs.InsertInBackground(
+                        offset_factor=0.2, background_audio=None, seed=random_generator
+                    ),
                     audaugs.Clip(offset_factor=0.5, duration_factor=0.25),
                     audaugs.Speed(factor=4.0),
                 ]

--- a/augly/tests/image_tests/pytorch_test.py
+++ b/augly/tests/image_tests/pytorch_test.py
@@ -3,13 +3,12 @@
 
 import unittest
 
+import augly.image as imaugs
 import torch
 import torchvision.transforms as transforms  # @manual
-from PIL import Image
-
-import augly.image as imaugs
 from augly.tests import ImageAugConfig
 from augly.utils import pathmgr
+from PIL import Image
 
 COLOR_JITTER_PARAMS = {
     "brightness_factor": 1.2,

--- a/augly/tests/text_tests/functional_unit_test.py
+++ b/augly/tests/text_tests/functional_unit_test.py
@@ -319,7 +319,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "7he qui{k brDwn 'fox' c0uldn' t jump ov3r the green, grassy hill.",
                 "+he quick |3rown 'f[]x' couldn' t jump Dver 7he green, grassy hill.",
-            ]
+            ],
         )
         augmented_chars_targetted = txtaugs.replace_similar_chars(
             self.texts[0],
@@ -333,7 +333,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "The quick 13rown 'fox' couldn' t jump ove/2 the gr3en, 9rassy hi|_l.",
                 "The quic|( brown 'fox' couldn' t jump over +he gree^, grassy hil!.",
-            ]
+            ],
         )
 
     def test_replace_similar_unicode_chars(self) -> None:
@@ -345,7 +345,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "†he qui⊂k browŅ 'fox' coỦldn' t jump o∨er the green, grassy hill.",
                 "The ჹuick brown 'ⓕox' couldn' t jumρ over the ġreen, grassy hilŀ.",
-            ]
+            ],
         )
         augmented_unicode_chars_targetted = txtaugs.replace_similar_unicode_chars(
             self.texts[0],
@@ -359,7 +359,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "Thė quick brown 'fox' couldn' t jump over ₸he grèen, gras$y hiḽl.",
                 "TΉe quick brown 'fox' couldn' t jump oveř the gree⋒, grasకy hiℒl.",
-            ]
+            ],
         )
 
     def test_replace_upside_down(self) -> None:
@@ -383,7 +383,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "Thǝ buiɔk qrown 'fox, couldn,t jump over ʇɥe green' gɹassʎ hill.",
                 "Ʇɥǝ qnᴉɔk qɹown 'fox' conldn,t jnɯp over the gɹeen, grassy ɥᴉll ˙",
-            ]
+            ],
         )
 
     def test_replace_words(self) -> None:
@@ -420,7 +420,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "Ther quick brown 'fox' couldn' t jump over the green, grassy hill.",
                 "Teh quick brown 'fox' couldn' t jump over tghe green, grassy hill.",
-            ]
+            ],
         )
 
         augmented_typos_targetted = txtaugs.simulate_typos(
@@ -434,8 +434,8 @@ class FunctionalTextUnitTest(unittest.TestCase):
             augmented_typos_targetted,
             [
                 "The quick buown 'fox' couldn' t jump over he rgeen, rgassy lhill.",
-                "The quick brown 'fox' couldn' t nump o^er the gre$n, grasys ill."
-            ]
+                "The quick brown 'fox' couldn' t nump o^er the gre$n, grasys ill.",
+            ],
         )
 
     def test_split_words(self) -> None:
@@ -445,7 +445,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "The qui ck brown 'fox' c ouldn't j ump over the green, grassy hi ll.",
                 "The qu ick bro wn 'fox' could n't jump over the gre en, grassy hill.",
-            ]
+            ],
         )
         augmented_split_words_targetted = txtaugs.split_words(
             self.texts[0], aug_word_p=0.3, n=2, priority_words=self.priority_words
@@ -455,7 +455,7 @@ class FunctionalTextUnitTest(unittest.TestCase):
             [
                 "The quick br own 'fox' couldn't jump over the g reen, gras sy h ill.",
                 "The quick brown 'fox' couldn't jump ov er the g reen, g rassy hi ll.",
-            ]
+            ],
         )
 
     def test_swap_gendered_words(self) -> None:

--- a/augly/tests/text_tests/transforms_unit_test.py
+++ b/augly/tests/text_tests/transforms_unit_test.py
@@ -35,7 +35,7 @@ def are_equal_metadata(
             if not (
                 isinstance(act_v, str)
                 and isinstance(exp_v, str)
-                and act_v[-len(exp_v):] == exp_v
+                and act_v[-len(exp_v) :] == exp_v
             ):
                 return False
 
@@ -62,9 +62,7 @@ class TransformsTextUnitTest(unittest.TestCase):
         with open(TEXT_METADATA_PATH, "r") as f:
             cls.expected_metadata = json.load(f)
 
-        cls.texts = [
-            "The quick brown 'fox' couldn't jump over the green, grassy hill."
-        ]
+        cls.texts = ["The quick brown 'fox' couldn't jump over the green, grassy hill."]
         cls.priority_words = ["green", "grassy", "hill"]
 
         cls.fairness_texts = [
@@ -101,7 +99,7 @@ class TransformsTextUnitTest(unittest.TestCase):
         )
 
         self.assertTrue(
-            augmented_words[0]== "I'd call him but I don't know where he's gone"
+            augmented_words[0] == "I'd call him but I don't know where he's gone"
         )
         self.assertTrue(
             are_equal_metadata(self.metadata, self.expected_metadata["contractions"])
@@ -340,7 +338,9 @@ class TransformsTextUnitTest(unittest.TestCase):
             == "The queen and king have a daughter named Raj and a son named Amanda.",
         )
         self.assertTrue(
-            are_equal_metadata(self.metadata, self.expected_metadata["swap_gendered_words"]),
+            are_equal_metadata(
+                self.metadata, self.expected_metadata["swap_gendered_words"]
+            ),
         )
 
 

--- a/augly/tests/video_tests/transforms/ffmpeg_test.py
+++ b/augly/tests/video_tests/transforms/ffmpeg_test.py
@@ -67,7 +67,9 @@ class TransformsVideoUnitTest(BaseVideoUnitTest):
         self.evaluate_class(vidaugs.Crop(), fname="crop")
 
     def test_EncodingQuality(self):
-        self.evaluate_class(vidaugs.EncodingQuality(quality=37), fname="encoding_quality")
+        self.evaluate_class(
+            vidaugs.EncodingQuality(quality=37), fname="encoding_quality"
+        )
 
     def test_FPS(self):
         self.evaluate_class(vidaugs.FPS(), fname="fps")
@@ -95,13 +97,17 @@ class TransformsVideoUnitTest(BaseVideoUnitTest):
         self.evaluate_class(vidaugs.Pad(), fname="pad")
 
     def test_RandomAspectRatio(self):
-        self.evaluate_class(vidaugs.RandomAspectRatio(), fname="RandomAspectRatio", seed=1)
+        self.evaluate_class(
+            vidaugs.RandomAspectRatio(), fname="RandomAspectRatio", seed=1
+        )
 
     def test_RandomBlur(self):
         self.evaluate_class(vidaugs.RandomBlur(), fname="RandomBlur", seed=1)
 
     def test_RandomBrightness(self):
-        self.evaluate_class(vidaugs.RandomBrightness(), fname="RandomBrightness", seed=1)
+        self.evaluate_class(
+            vidaugs.RandomBrightness(), fname="RandomBrightness", seed=1
+        )
 
     def test_RandomContrast(self):
         self.evaluate_class(vidaugs.RandomContrast(), fname="RandomContrast", seed=1)
@@ -121,7 +127,9 @@ class TransformsVideoUnitTest(BaseVideoUnitTest):
         self.evaluate_class(vidaugs.RandomRotation(), fname="RandomRotation", seed=1)
 
     def test_RandomVideoSpeed(self):
-        self.evaluate_class(vidaugs.RandomVideoSpeed(), fname="RandomVideoSpeed", seed=1)
+        self.evaluate_class(
+            vidaugs.RandomVideoSpeed(), fname="RandomVideoSpeed", seed=1
+        )
 
     def test_RemoveAudio(self):
         self.evaluate_class(vidaugs.RemoveAudio(), fname="remove_audio")

--- a/augly/tests/video_tests/transforms/image_based_test.py
+++ b/augly/tests/video_tests/transforms/image_based_test.py
@@ -34,7 +34,10 @@ class TransformsVideoUnitTest(BaseVideoUnitTest):
             vidaugs.OverlayOntoScreenshot(),
             fname="overlay_onto_screenshot",
             metadata_exclude_keys=[
-                "dst_height", "dst_width", "intensity", "template_filepath"
+                "dst_height",
+                "dst_width",
+                "intensity",
+                "template_filepath",
             ],
         )
 

--- a/augly/text/__init__.py
+++ b/augly/text/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 from augly.text.composition import Compose, OneOf
-
 from augly.text.functional import (
     apply_lambda,
     change_case,
@@ -22,7 +21,6 @@ from augly.text.functional import (
     split_words,
     swap_gendered_words,
 )
-
 from augly.text.intensity import (
     apply_lambda_intensity,
     change_case_intensity,
@@ -42,7 +40,6 @@ from augly.text.intensity import (
     split_words_intensity,
     swap_gendered_words_intensity,
 )
-
 from augly.text.transforms import (
     ApplyLambda,
     ChangeCase,

--- a/augly/text/augmenters/__init__.py
+++ b/augly/text/augmenters/__init__.py
@@ -8,10 +8,10 @@ from augly.text.augmenters.contraction import ContractionAugmenter
 from augly.text.augmenters.fun_fonts import FunFontsAugmenter
 from augly.text.augmenters.insertion import InsertionAugmenter
 from augly.text.augmenters.letter_replacement import LetterReplacementAugmenter
-from augly.text.augmenters.words_augmenter import WordsAugmenter
 from augly.text.augmenters.typo import TypoAugmenter
 from augly.text.augmenters.upside_down import UpsideDownAugmenter
 from augly.text.augmenters.word_replacement import WordReplacementAugmenter
+from augly.text.augmenters.words_augmenter import WordsAugmenter
 
 
 __all__ = [

--- a/augly/text/augmenters/case.py
+++ b/augly/text/augmenters/case.py
@@ -2,9 +2,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
-import numpy as np
 from typing import List, Optional, Union
 
+import numpy as np
 from augly.text.augmenters.utils import (
     rejoin_words_and_whitespace,
     split_words_on_whitespace,
@@ -46,11 +46,16 @@ class CaseAugmenter(object):
         seed: Optional[int] = 10,
     ):
         assert granularity in {
-            "char", "word", "all"
+            "char",
+            "word",
+            "all",
         }, "Must set 'granularity' to either 'word' or 'all'."
         assert cadence >= 1.0, "Must set 'cadence' to be no less than 1.0."
         assert case in {
-            "lower", "upper", "title", "random"
+            "lower",
+            "upper",
+            "title",
+            "random",
         }, "'case' must be one of: lower, upper, title, random"
 
         self.case_changer = CaseChanger(case, seed)

--- a/augly/text/augmenters/contraction.py
+++ b/augly/text/augmenters/contraction.py
@@ -2,9 +2,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import json
-import numpy as np
 from typing import Any, Dict, List, Optional, Union
 
+import numpy as np
 from augly.text.augmenters.utils import (
     detokenize,
     tokenize,
@@ -22,7 +22,6 @@ class ContractionMapping(object):
             self.mapping = mapping
         else:
             self.mapping = {}
-
 
     def replace(self, text: str) -> Optional[str]:
         new_text = self.mapping.get(text.lower(), None)

--- a/augly/text/augmenters/fun_fonts.py
+++ b/augly/text/augmenters/fun_fonts.py
@@ -62,7 +62,7 @@ class FunFontsAugmenter(Augmenter):
         """
         local_fonts_path = pathmgr.get_local_path(fonts_path)
 
-        with open(local_fonts_path, encoding='utf-8') as text_file:
+        with open(local_fonts_path, encoding="utf-8") as text_file:
             font_dictionary = json.load(text_file)
             return list(font_dictionary.values())
 

--- a/augly/text/augmenters/insertion.py
+++ b/augly/text/augmenters/insertion.py
@@ -24,7 +24,7 @@ CHARACTER_TYPES = {
         "\u2064",  # Invisible Plus
     ],
     "whitespace": [
-        " ",   # Space
+        " ",  # Space
         "\t",  # Horizontal Tab
         "\n",  # Newline
         "\r",  # Carriage Return

--- a/augly/text/augmenters/letter_replacement.py
+++ b/augly/text/augmenters/letter_replacement.py
@@ -93,9 +93,7 @@ class LetterReplacementAugmenter(CharAugmenter):
         )
         filtered_word_idxes = self.skip_aug(self.pre_skip_aug(tokens), tokens)
         aug_word_idxes = set(
-            get_aug_idxes(
-                self, tokens, filtered_word_idxes, aug_word_cnt, Method.WORD
-            )
+            get_aug_idxes(self, tokens, filtered_word_idxes, aug_word_cnt, Method.WORD)
         )
 
         for t_i, token in enumerate(tokens):

--- a/augly/text/augmenters/typo.py
+++ b/augly/text/augmenters/typo.py
@@ -27,7 +27,9 @@ class MisspellingReplacement(object):
             self.dictionary = json.load(json_file)
 
     def replace(self, word: str) -> Optional[List[str]]:
-        return self.dictionary.get(word, None) or self.dictionary.get(word.lower(), None)
+        return self.dictionary.get(word, None) or self.dictionary.get(
+            word.lower(), None
+        )
 
 
 class TypoAugmenter(WordAugmenter):
@@ -61,9 +63,12 @@ class TypoAugmenter(WordAugmenter):
             aug_word_p,
         )
 
-        assert (
-            typo_type in ["all", "charmix", "keyboard", "misspelling"]
-        ), "Typo type must be one of: all, charmix, keyboard, misspelling"
+        assert typo_type in [
+            "all",
+            "charmix",
+            "keyboard",
+            "misspelling",
+        ], "Typo type must be one of: all, charmix, keyboard, misspelling"
 
         super().__init__(
             action=Action.SUBSTITUTE,
@@ -74,7 +79,12 @@ class TypoAugmenter(WordAugmenter):
 
         self.augmenters, self.model = [], None
         if typo_type in ["all", "charmix"]:
-            for action in [Action.DELETE, Action.INSERT, Action.SUBSTITUTE, Action.SWAP]:
+            for action in [
+                Action.DELETE,
+                Action.INSERT,
+                Action.SUBSTITUTE,
+                Action.SWAP,
+            ]:
                 self.augmenters.append(
                     RandomCharAug(
                         action=action,
@@ -136,9 +146,7 @@ class TypoAugmenter(WordAugmenter):
         )
         filtered_word_idxes = self.skip_aug(self.pre_skip_aug(tokens), tokens)
         aug_word_idxes = set(
-            get_aug_idxes(
-                self, tokens, filtered_word_idxes, aug_word_cnt, Method.WORD
-            )
+            get_aug_idxes(self, tokens, filtered_word_idxes, aug_word_cnt, Method.WORD)
         )
 
         for t_i, token in enumerate(tokens):

--- a/augly/text/augmenters/utils.py
+++ b/augly/text/augmenters/utils.py
@@ -2,9 +2,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import re
-import regex
 from typing import List, Optional, Tuple
 
+import regex
 from augly.utils.libsndfile import install_libsndfile
 
 
@@ -245,10 +245,9 @@ def get_aug_idxes(
     idxes = []
     for i in filtered_idxes:
         if i not in priority_idxes:
-            if (
-                (min_char is None or len(tokens[i]) >= min_char)
-                and tokens[i].lower() not in ignore_words
-            ):
+            if (min_char is None or len(tokens[i]) >= min_char) and tokens[
+                i
+            ].lower() not in ignore_words:
                 idxes.append(i)
 
     if len(priority_idxes) + len(idxes) == 0:

--- a/augly/text/augmenters/word_replacement.py
+++ b/augly/text/augmenters/word_replacement.py
@@ -29,7 +29,6 @@ class WordReplacement(object):
         else:
             self.mapping = {}
 
-
     def replace(self, word: str) -> str:
         new_word = self.mapping.get(word, None) or self.mapping.get(word.lower(), None)
         if new_word is not None and word[0].isupper():

--- a/augly/text/augmenters/words_augmenter.py
+++ b/augly/text/augmenters/words_augmenter.py
@@ -66,7 +66,7 @@ class WordsAugmenter(WordAugmenter):
             return data
 
         t_i = 0
-        while(t_i < len(tokens)):
+        while t_i < len(tokens):
             if t_i in aug_word_idxes and len(tokens[t_i + 1]) >= self.min_char:
                 results.append(tokens[t_i] + tokens[t_i + 1])
                 t_i += 1

--- a/augly/text/intensity.py
+++ b/augly/text/intensity.py
@@ -58,14 +58,18 @@ def replace_similar_chars_intensity(
     aug_char_p: float, aug_word_p: float, aug_char_max: int, aug_word_max: int, **kwargs
 ) -> float:
     # we only care if aug_*_max is zero or not, so it's okay to multiply the values here
-    return replace_intensity_helper(aug_word_p * aug_char_p, aug_word_max * aug_char_max)
+    return replace_intensity_helper(
+        aug_word_p * aug_char_p, aug_word_max * aug_char_max
+    )
 
 
 def replace_similar_unicode_chars_intensity(
     aug_char_p: float, aug_word_p: float, aug_char_max: int, aug_word_max: int, **kwargs
 ) -> float:
     # we only care if aug_*_max is zero or not, so it's okay to multiply the values here
-    return replace_intensity_helper(aug_word_p * aug_char_p, aug_word_max * aug_char_max)
+    return replace_intensity_helper(
+        aug_word_p * aug_char_p, aug_word_max * aug_char_max
+    )
 
 
 def replace_upside_down_intensity(
@@ -80,18 +84,16 @@ def replace_words_intensity(
     mapping: Optional[Union[str, Dict[str, Any]]],
     **kwargs,
 ) -> float:
-    return (
-        0.0
-        if not mapping
-        else replace_intensity_helper(aug_word_p, aug_word_max)
-    )
+    return 0.0 if not mapping else replace_intensity_helper(aug_word_p, aug_word_max)
 
 
 def simulate_typos_intensity(
     aug_char_p: float, aug_word_p: float, aug_char_max: int, aug_word_max: int, **kwargs
 ) -> float:
     # we only care if aug_*_max is zero or not, so it's okay to multiply the values here
-    return replace_intensity_helper(aug_word_p * aug_char_p, aug_word_max * aug_char_max)
+    return replace_intensity_helper(
+        aug_word_p * aug_char_p, aug_word_max * aug_char_max
+    )
 
 
 def split_words_intensity(aug_word_p: float, aug_word_max: int, **kwargs) -> float:

--- a/augly/text/utils.py
+++ b/augly/text/utils.py
@@ -62,8 +62,8 @@ def get_gendered_words_mapping(mapping: Union[str, Dict[str, str]]) -> Dict[str,
     written by Adina Williams and has been used in influential work, e.g.
     https://arxiv.org/pdf/2005.00614.pdf
     """
-    assert (
-        isinstance(mapping, (str, Dict))
+    assert isinstance(
+        mapping, (str, Dict)
     ), "Mapping must be either a dict or filepath to a mapping of gendered words"
 
     if isinstance(mapping, Dict):

--- a/augly/utils/__init__.py
+++ b/augly/utils/__init__.py
@@ -29,7 +29,6 @@ from augly.utils.base_paths import (
     VIDEO_METADATA_PATH,
 )
 from augly.utils.classes import Segment
-from augly.utils.functions import compute_time_crop_segments
 from augly.utils.constants import (
     BBOXES_PATH,
     CONTRACTIONS_MAPPING,
@@ -53,6 +52,7 @@ from augly.utils.constants import (
     UNICODE_MAPPING_PATH,
     WHITE_RGB_COLOR,
 )
+from augly.utils.functions import compute_time_crop_segments
 from augly.utils.io import pathmgr
 
 

--- a/augly/utils/asserts.py
+++ b/augly/utils/asserts.py
@@ -36,8 +36,8 @@ def validate_audio_path(audio_path: str) -> None:
 
     # since `librosa` can extract audio from audio and video
     # paths, we check for both here
-    assert (
-        is_audio_file(audio_path) or is_video_file(audio_path)
+    assert is_audio_file(audio_path) or is_video_file(
+        audio_path
     ), f"Audio path invalid: {audio_path}"
 
 

--- a/augly/utils/constants.py
+++ b/augly/utils/constants.py
@@ -27,11 +27,7 @@ DEFAULT_SAMPLE_RATE = 44100
 DEFAULT_TEXT_INDICES = [random.randrange(1, 1000) for _ in range(5)]
 
 # `overlay_stripes` constants
-SUPPORTED_LINE_TYPES = [
-    "dotted",
-    "dashed",
-    "solid"
-]
+SUPPORTED_LINE_TYPES = ["dotted", "dashed", "solid"]
 
 # screenshot augmentation assets
 BBOXES_PATH = os.path.join(SCREENSHOT_TEMPLATES_DIR, "bboxes.json")

--- a/augly/utils/ffmpeg.py
+++ b/augly/utils/ffmpeg.py
@@ -9,19 +9,19 @@ FFMPEG_PATH = os.environ.get("AUGLY_FFMPEG_PATH", None)
 FFPROBE_PATH = os.environ.get("AUGLY_FFPROBE_PATH", None)
 
 if FFMPEG_PATH is None:
-    FFMPEG_PATH = spawn.find_executable('ffmpeg')
+    FFMPEG_PATH = spawn.find_executable("ffmpeg")
 
 if FFPROBE_PATH is None:
-    FFPROBE_PATH = spawn.find_executable('ffprobe')
+    FFPROBE_PATH = spawn.find_executable("ffprobe")
 
 ffmpeg_paths_error = (
     "Please install 'ffmpeg' or set the {} & {} environment variables "
     "before running AugLy Video"
 )
 
-assert (
-    FFMPEG_PATH is not None and FFPROBE_PATH is not None
-), ffmpeg_paths_error.format("AUGLY_FFMPEG_PATH", "AUGLY_FFPROBE_PATH")
+assert FFMPEG_PATH is not None and FFPROBE_PATH is not None, ffmpeg_paths_error.format(
+    "AUGLY_FFMPEG_PATH", "AUGLY_FFPROBE_PATH"
+)
 
 
 def get_conditional_for_skipping_video_tests() -> Tuple[bool, str]:

--- a/augly/utils/libsndfile.py
+++ b/augly/utils/libsndfile.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+
 def install_libsndfile():
     pass

--- a/augly/video/__init__.py
+++ b/augly/video/__init__.py
@@ -2,7 +2,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 from augly.video.composition import Compose, OneOf
-
 from augly.video.functional import (
     add_noise,
     apply_lambda,
@@ -47,7 +46,6 @@ from augly.video.functional import (
     vflip,
     vstack,
 )
-
 from augly.video.transforms import (
     AddNoise,
     ApplyLambda,

--- a/augly/video/augmenters/cv2/__init__.py
+++ b/augly/video/augmenters/cv2/__init__.py
@@ -2,8 +2,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 from augly.video.augmenters.cv2.base_augmenter import BaseCV2Augmenter
-from augly.video.augmenters.cv2.shapes import VideoDistractorByShapes
 from augly.video.augmenters.cv2.dots import VideoDistractorByDots
+from augly.video.augmenters.cv2.shapes import VideoDistractorByShapes
 from augly.video.augmenters.cv2.text import VideoDistractorByText
 
 

--- a/augly/video/augmenters/cv2/dots.py
+++ b/augly/video/augmenters/cv2/dots.py
@@ -5,7 +5,8 @@ import logging
 
 import cv2
 import numpy as np
-from augly.video.augmenters.cv2 import BaseCV2Augmenter, VideoDistractorByShapes
+from augly.video.augmenters.cv2.base_augmenter import BaseCV2Augmenter
+from augly.video.augmenters.cv2.shapes import VideoDistractorByShapes
 
 
 logger = logging.getLogger(__name__)

--- a/augly/video/augmenters/cv2/shapes.py
+++ b/augly/video/augmenters/cv2/shapes.py
@@ -6,7 +6,7 @@ from typing import Optional, List, Tuple, Iterator
 
 import cv2
 import numpy as np
-from augly.video.augmenters.cv2 import BaseCV2Augmenter
+from augly.video.augmenters.cv2.base_augmenter import BaseCV2Augmenter
 
 
 class VideoDistractorByShapes(BaseCV2Augmenter):

--- a/augly/video/augmenters/cv2/text.py
+++ b/augly/video/augmenters/cv2/text.py
@@ -9,7 +9,7 @@ from typing import Any, List, Iterator, Optional, Tuple
 import cv2
 import numpy as np
 from augly.utils import pathmgr
-from augly.video.augmenters.cv2 import BaseCV2Augmenter
+from augly.video.augmenters.cv2.base_augmenter import BaseCV2Augmenter
 from PIL import Image, ImageDraw, ImageFont
 
 
@@ -150,9 +150,18 @@ class VideoDistractorByText(BaseCV2Augmenter):
             #  got `Union[ImageFont.FreeTypeFont, ImageFont.ImageFont,
             #  ImageFont.TransposedFont]`.
             ImageDraw.Draw(distract_frame_pil).text((x, y), text_str, font=font)
-            distract_frame = cv2.cvtColor(np.array(distract_frame_pil), cv2.COLOR_RGB2BGR)
+            distract_frame = cv2.cvtColor(
+                np.array(distract_frame_pil), cv2.COLOR_RGB2BGR
+            )
         else:
             cv2.putText(
-                distract_frame, text_str, (x, y), font, fontscale, color, thickness, cv2.LINE_AA
+                distract_frame,
+                text_str,
+                (x, y),
+                font,
+                fontscale,
+                color,
+                thickness,
+                cv2.LINE_AA,
             )
         return distract_frame

--- a/augly/video/augmenters/ffmpeg/__init__.py
+++ b/augly/video/augmenters/ffmpeg/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.augmenters.ffmpeg.aspect_ratio import VideoAugmenterByAspectRatio
 from augly.video.augmenters.ffmpeg.audio_swap import VideoAugmenterByAudioSwap
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.augmenters.ffmpeg.blur import VideoAugmenterByBlur
 from augly.video.augmenters.ffmpeg.brightness import VideoAugmenterByBrightness
 from augly.video.augmenters.ffmpeg.color_jitter import VideoAugmenterByColorJitter
@@ -14,14 +14,14 @@ from augly.video.augmenters.ffmpeg.fps import VideoAugmenterByFPSChange
 from augly.video.augmenters.ffmpeg.grayscale import VideoAugmenterByGrayscale
 from augly.video.augmenters.ffmpeg.hflip import VideoAugmenterByHFlip
 from augly.video.augmenters.ffmpeg.loops import VideoAugmenterByLoops
+from augly.video.augmenters.ffmpeg.no_audio import VideoAugmenterByRemovingAudio
 from augly.video.augmenters.ffmpeg.noise import VideoAugmenterByNoise
 from augly.video.augmenters.ffmpeg.overlay import VideoAugmenterByOverlay
 from augly.video.augmenters.ffmpeg.pad import VideoAugmenterByPadding
-from augly.video.augmenters.ffmpeg.no_audio import VideoAugmenterByRemovingAudio
+from augly.video.augmenters.ffmpeg.quality import VideoAugmenterByQuality
 from augly.video.augmenters.ffmpeg.resize import VideoAugmenterByResize
 from augly.video.augmenters.ffmpeg.resolution import VideoAugmenterByResolution
 from augly.video.augmenters.ffmpeg.rotate import VideoAugmenterByRotation
-from augly.video.augmenters.ffmpeg.quality import VideoAugmenterByQuality
 from augly.video.augmenters.ffmpeg.speed import VideoAugmenterBySpeed
 from augly.video.augmenters.ffmpeg.stack import VideoAugmenterByStack
 from augly.video.augmenters.ffmpeg.trim import VideoAugmenterByTrim

--- a/augly/video/augmenters/ffmpeg/aspect_ratio.py
+++ b/augly/video/augmenters/ffmpeg/aspect_ratio.py
@@ -4,16 +4,15 @@
 import math
 from typing import Dict, Tuple, Union
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_video_info
 from ffmpeg.nodes import FilterableStream
 
 
 class VideoAugmenterByAspectRatio(BaseFFMPEGAugmenter):
     def __init__(self, ratio: Union[float, str]):
-        assert (
-            (isinstance(ratio, str) and len(ratio.split(":")) == 2)
-            or (isinstance(ratio, (int, float)) and ratio > 0)
+        assert (isinstance(ratio, str) and len(ratio.split(":")) == 2) or (
+            isinstance(ratio, (int, float)) and ratio > 0
         ), "Aspect ratio must be a valid string ratio or a positive number"
         self.aspect_ratio = ratio
 

--- a/augly/video/augmenters/ffmpeg/audio_swap.py
+++ b/augly/video/augmenters/ffmpeg/audio_swap.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 
 import ffmpeg  # @manual
 from augly.utils import pathmgr
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_audio_info, get_video_info
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/base_augmenter.py
+++ b/augly/video/augmenters/ffmpeg/base_augmenter.py
@@ -16,9 +16,9 @@ from abc import ABC, abstractmethod
 from typing import Dict, Tuple
 
 import ffmpeg  # @manual
-from ffmpeg.nodes import FilterableStream
 from augly.utils.ffmpeg import FFMPEG_PATH
 from augly.video.helpers import has_audio_stream
+from ffmpeg.nodes import FilterableStream
 
 
 class BaseFFMPEGAugmenter(ABC):

--- a/augly/video/augmenters/ffmpeg/blur.py
+++ b/augly/video/augmenters/ffmpeg/blur.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/brightness.py
+++ b/augly/video/augmenters/ffmpeg/brightness.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/color_jitter.py
+++ b/augly/video/augmenters/ffmpeg/color_jitter.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/concat.py
+++ b/augly/video/augmenters/ffmpeg/concat.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple
 
 import ffmpeg  # @manual
 from augly.utils import pathmgr
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_video_info
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/contrast.py
+++ b/augly/video/augmenters/ffmpeg/contrast.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/crop.py
+++ b/augly/video/augmenters/ffmpeg/crop.py
@@ -3,7 +3,7 @@
 
 from typing import Dict, Tuple
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_video_info
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/fps.py
+++ b/augly/video/augmenters/ffmpeg/fps.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/grayscale.py
+++ b/augly/video/augmenters/ffmpeg/grayscale.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/hflip.py
+++ b/augly/video/augmenters/ffmpeg/hflip.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/loops.py
+++ b/augly/video/augmenters/ffmpeg/loops.py
@@ -4,7 +4,7 @@
 from typing import Tuple, Dict
 
 import ffmpeg  # @manual
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/no_audio.py
+++ b/augly/video/augmenters/ffmpeg/no_audio.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/noise.py
+++ b/augly/video/augmenters/ffmpeg/noise.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/overlay.py
+++ b/augly/video/augmenters/ffmpeg/overlay.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 
 import ffmpeg  # @manual
 from augly.utils import is_image_file, is_video_file, pathmgr
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_video_info
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/pad.py
+++ b/augly/video/augmenters/ffmpeg/pad.py
@@ -4,7 +4,7 @@
 from typing import Dict, Tuple
 
 from augly.utils import validate_rgb_color
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_video_info
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/quality.py
+++ b/augly/video/augmenters/ffmpeg/quality.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/resize.py
+++ b/augly/video/augmenters/ffmpeg/resize.py
@@ -3,7 +3,7 @@
 
 from typing import Dict, Optional, Tuple
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/resolution.py
+++ b/augly/video/augmenters/ffmpeg/resolution.py
@@ -3,7 +3,7 @@
 
 from typing import Dict, Tuple
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/rotate.py
+++ b/augly/video/augmenters/ffmpeg/rotate.py
@@ -4,7 +4,7 @@
 import math
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/augmenters/ffmpeg/speed.py
+++ b/augly/video/augmenters/ffmpeg/speed.py
@@ -4,7 +4,7 @@
 from typing import Tuple, Dict
 
 import ffmpeg  # @manual
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import has_audio_stream
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/stack.py
+++ b/augly/video/augmenters/ffmpeg/stack.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 
 import ffmpeg  # @manual
 from augly.utils import pathmgr
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_video_info
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/trim.py
+++ b/augly/video/augmenters/ffmpeg/trim.py
@@ -4,7 +4,7 @@
 from typing import Dict, Optional, Tuple
 
 import ffmpeg  # @manual
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from augly.video.helpers import get_video_info, has_audio_stream
 from ffmpeg.nodes import FilterableStream
 

--- a/augly/video/augmenters/ffmpeg/vflip.py
+++ b/augly/video/augmenters/ffmpeg/vflip.py
@@ -3,7 +3,7 @@
 
 from typing import Tuple, Dict
 
-from augly.video.augmenters.ffmpeg import BaseFFMPEGAugmenter
+from augly.video.augmenters.ffmpeg.base_augmenter import BaseFFMPEGAugmenter
 from ffmpeg.nodes import FilterableStream
 
 

--- a/augly/video/composition.py
+++ b/augly/video/composition.py
@@ -5,8 +5,8 @@ import random
 import shutil
 from typing import Any, Dict, List, Optional
 
-from augly.video.transforms import VidAugBaseClass
 from augly.video.helpers import validate_input_and_output_paths
+from augly.video.transforms import VidAugBaseClass
 
 
 """

--- a/augly/video/functional.py
+++ b/augly/video/functional.py
@@ -774,7 +774,7 @@ def insert_in_background(
             num_loops_needed = math.ceil(desired_bg_duration / bg_video_duration)
             if num_loops_needed > 1:
                 loop(resized_bg_path, num_loops=num_loops_needed)
-                bg_video_duration*=num_loops_needed
+                bg_video_duration *= num_loops_needed
 
             bg_start = rng.uniform(0, bg_video_duration - desired_bg_duration)
             bg_end = bg_start + desired_bg_duration

--- a/augly/video/helpers/__init__.py
+++ b/augly/video/helpers/__init__.py
@@ -11,7 +11,6 @@ from augly.video.helpers.ffmpeg import (
     get_video_info,
     has_audio_stream,
 )
-
 from augly.video.helpers.intensity import (
     add_noise_intensity,
     apply_lambda_intensity,
@@ -55,7 +54,6 @@ from augly.video.helpers.intensity import (
     vflip_intensity,
     vstack_intensity,
 )
-
 from augly.video.helpers.metadata import (
     compute_changed_segments,
     compute_segments,
@@ -64,7 +62,6 @@ from augly.video.helpers.metadata import (
     get_func_kwargs,
     get_metadata,
 )
-
 from augly.video.helpers.utils import (
     create_color_video,
     create_video_from_image,

--- a/augly/video/helpers/ffmpeg.py
+++ b/augly/video/helpers/ffmpeg.py
@@ -49,8 +49,7 @@ def extract_audio_to_file(video_path: str, output_audio_path: str) -> None:
         )
     else:
         out, err = (
-            ffmpeg
-            .input(video_path, loglevel="quiet")
+            ffmpeg.input(video_path, loglevel="quiet")
             .output("-", format="f32le", acodec="pcm_f32le", ac=1, ar=sample_rate)
             .run(cmd=FFMPEG_PATH, capture_stdout=True, capture_stderr=True)
         )

--- a/augly/video/helpers/intensity.py
+++ b/augly/video/helpers/intensity.py
@@ -169,10 +169,8 @@ def meme_format_intensity(metadata: Dict[str, Any], **kwargs) -> float:
 def overlay_intensity(
     overlay_size: Optional[float], overlay_path: str, metadata: Dict[str, Any], **kwargs
 ) -> float:
-    assert (
-        overlay_size is None or (
-            isinstance(overlay_size, (float, int)) and 0 < overlay_size <= 1
-        )
+    assert overlay_size is None or (
+        isinstance(overlay_size, (float, int)) and 0 < overlay_size <= 1
     ), "overlay_size must be a value in the range (0, 1]"
     if overlay_size is not None:
         return (overlay_size ** 2) * 100.0
@@ -283,6 +281,7 @@ def pixelization_intensity(ratio: float, **kwargs) -> float:
 def remove_audio_intensity(**kwargs) -> float:
     return 100.0
 
+
 def replace_with_background_intensity(metadata: Dict[str, Any], **kwargs) -> float:
     """
     The intensity of replace_with_background is the fraction of the source video duration
@@ -291,8 +290,12 @@ def replace_with_background_intensity(metadata: Dict[str, Any], **kwargs) -> flo
     greater than 100.
     """
     src_duration = metadata["src_duration"]
-    total_bg_duration = metadata["starting_background_duration"] + metadata["ending_background_duration"]
+    total_bg_duration = (
+        metadata["starting_background_duration"]
+        + metadata["ending_background_duration"]
+    )
     return min((total_bg_duration / src_duration) * 100.0, 100.0)
+
 
 def replace_with_color_frames_intensity(
     duration_factor: float, offset_factor: float, **kwargs

--- a/augly/video/helpers/metadata.py
+++ b/augly/video/helpers/metadata.py
@@ -150,7 +150,10 @@ def compute_changed_segments(
             clip_start = kwargs["starting_background_duration"]
             duration = kwargs["source_duration"]
             new_dst_segments.append(
-                Segment(dst_segment.start + clip_start, dst_segment.start + clip_start + duration)
+                Segment(
+                    dst_segment.start + clip_start,
+                    dst_segment.start + clip_start + duration,
+                )
             )
         elif name == "change_video_speed":
             # speed_factor > 1 if speedup, < 1 if slow down

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,18 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-import setuptools
 from pathlib import Path
+
+import setuptools
 
 
 requirements = [
-    r
-    for r in Path("requirements.txt").read_text().splitlines()
-    if '@' not in r
+    r for r in Path("requirements.txt").read_text().splitlines() if "@" not in r
 ]
 
 extra_requirements = {
     "av": [
-        r
-        for r in Path("av_requirements.txt").read_text().splitlines()
-        if '@' not in r
+        r for r in Path("av_requirements.txt").read_text().splitlines() if "@" not in r
     ]
 }
 
@@ -39,7 +36,7 @@ setuptools.setup(
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent"
+        "Operating System :: OS Independent",
     ],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
Summary:
Now our files are all correctly formatted for `black`, and thus we can run `black` on our files during code review & not have a million irrelevant changes!

Followed the steps here: https://fb.prod.workplace.com/groups/pythonfoundation/posts/2990917737888352/
- Removed `aml/augly/` from list of dirs excluded from black formatting in `fbsource/tools/arcanist/lint/fbsource-lint-engine.toml`
- Ran `arc lint --take BLACK --apply-patches --paths-cmd 'hg files aml/augly/'`
- Fixed type issues in `aml/augly/text/fb/augmenters/back_translate/` which were causing linter errors (there were `pyre-ignore` comments but they were no longer on the correct line post-`black`, so just added an assert & initialized a var so we no longer need them)
- Made changes to TARGETS files suggested by linter (moving imports/changing from where some libraries were imported)

Differential Revision: D31526814

