### PR TITLE
Allow param overriding with kwargs in transform classes' __call__

### DIFF
--- a/augly/text/transforms.py
+++ b/augly/text/transforms.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 
+import inspect
 import random
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -32,6 +33,7 @@ class BaseTransform(object):
         texts: Union[str, List[str]],
         force: bool = False,
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **kwargs,
     ) -> List[str]:
         """
         @param texts: a string or a list of text documents to be augmented
@@ -43,6 +45,9 @@ class BaseTransform(object):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
         assert isinstance(
@@ -53,17 +58,36 @@ class BaseTransform(object):
         if not force and random.random() > self.p:
             return texts if isinstance(texts, list) else [texts]
 
-        return self.apply_transform(texts, metadata)
+        return self.apply_transform(texts, metadata, **self.get_aug_kwargs(**kwargs))
+
+    def get_aug_kwargs(self, **kwargs) -> Dict[str, Any]:
+        """
+        @param kwargs: any kwargs that were passed into __call__() intended to override
+            the instance variables set in __init__() when calling the augmentation
+            function in apply_transform()
+
+        @returns: the kwargs that should be passed into the augmentation function
+            apply_transform() -- this will be the instance variables set in __init__(),
+            potentially overridden by anything passed in as kwargs
+        """
+        attrs = {
+            k: v
+            for k, v in inspect.getmembers(self)
+            if k not in {"apply_transform", "get_aug_kwargs", "p"}
+            and not k.startswith("__")
+        }
+        return {**attrs, **kwargs}
 
     def apply_transform(
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
-        This function is to be implemented in the child classes.
-        From this function, call the augmentation function with the
-        parameters specified
+        This function is to be implemented in the child classes. From this function, call
+        the augmentation function, passing in 'texts', 'metadata', & the given
+        'aug_kwargs'
         """
         raise NotImplementedError()
 
@@ -109,6 +133,7 @@ class ApplyLambda(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Apply a user-defined lambda on a list of text documents
@@ -119,11 +144,13 @@ class ApplyLambda(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.apply_lambda(
-            texts, self.aug_function, **self.kwargs, metadata=metadata
-        )
+        lambda_kwargs = aug_kwargs.pop("kwargs")
+        return F.apply_lambda(texts, metadata=metadata, **lambda_kwargs, **aug_kwargs)
 
 
 class ChangeCase(BaseTransform):
@@ -162,6 +189,7 @@ class ChangeCase(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Changes the case (e.g. upper, lower, title) of random chars, words, or the entire
@@ -173,16 +201,12 @@ class ChangeCase(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.change_case(
-            texts,
-            granularity=self.granularity,
-            cadence=self.cadence,
-            case=self.case,
-            seed=self.seed,
-            metadata=metadata,
-        )
+        return F.change_case(texts, metadata=metadata, **aug_kwargs)
 
 
 class Contractions(BaseTransform):
@@ -220,6 +244,7 @@ class Contractions(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Replaces pairs (or longer strings) of words with contractions given a mapping
@@ -230,16 +255,12 @@ class Contractions(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.contractions(
-            texts,
-            aug_p=self.aug_p,
-            mapping=self.mapping,
-            max_contraction_length=self.max_contraction_length,
-            seed=self.seed,
-            metadata=metadata,
-        )
+        return F.contractions(texts, metadata=metadata, **aug_kwargs)
 
 
 class GetBaseline(BaseTransform):
@@ -247,6 +268,7 @@ class GetBaseline(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Generates a baseline by tokenizing and detokenizing the text
@@ -257,9 +279,12 @@ class GetBaseline(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.get_baseline(texts, metadata=metadata)
+        return F.get_baseline(texts, metadata=metadata, **aug_kwargs)
 
 
 class InsertPunctuationChars(BaseTransform):
@@ -292,6 +317,7 @@ class InsertPunctuationChars(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Inserts punctuation characters in each input text
@@ -302,15 +328,12 @@ class InsertPunctuationChars(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.insert_punctuation_chars(
-            texts,
-            granularity=self.granularity,
-            cadence=self.cadence,
-            vary_chars=self.vary_chars,
-            metadata=metadata,
-        )
+        return F.insert_punctuation_chars(texts, metadata=metadata, **aug_kwargs)
 
 
 class InsertWhitespaceChars(BaseTransform):
@@ -343,6 +366,7 @@ class InsertWhitespaceChars(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Inserts whitespace characters in each input text
@@ -353,15 +377,12 @@ class InsertWhitespaceChars(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.insert_whitespace_chars(
-            texts,
-            granularity=self.granularity,
-            cadence=self.cadence,
-            vary_chars=self.vary_chars,
-            metadata=metadata,
-        )
+        return F.insert_whitespace_chars(texts, metadata=metadata, **aug_kwargs)
 
 
 class InsertZeroWidthChars(BaseTransform):
@@ -394,6 +415,7 @@ class InsertZeroWidthChars(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Inserts zero-width characters in each input text
@@ -404,15 +426,12 @@ class InsertZeroWidthChars(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.insert_zero_width_chars(
-            texts,
-            granularity=self.granularity,
-            cadence=self.cadence,
-            vary_chars=self.vary_chars,
-            metadata=metadata,
-        )
+        return F.insert_zero_width_chars(texts, metadata=metadata, **aug_kwargs)
 
 
 class MergeWords(BaseTransform):
@@ -454,6 +473,7 @@ class MergeWords(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Merges words in the text together
@@ -464,18 +484,12 @@ class MergeWords(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.merge_words(
-            texts,
-            aug_word_p=self.aug_word_p,
-            min_char=self.min_char,
-            aug_word_min=self.aug_word_min,
-            aug_word_max=self.aug_word_max,
-            n=self.n,
-            priority_words=self.priority_words,
-            metadata=metadata,
-        )
+        return F.merge_words(texts, metadata=metadata, **aug_kwargs)
 
 
 class ReplaceBidirectional(BaseTransform):
@@ -502,6 +516,7 @@ class ReplaceBidirectional(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Reverses each word (or part of the word) in each input text and uses
@@ -514,14 +529,12 @@ class ReplaceBidirectional(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.replace_bidirectional(
-            texts,
-            granularity=self.granularity,
-            split_word=self.split_word,
-            metadata=metadata,
-        )
+        return F.replace_bidirectional(texts, metadata=metadata, **aug_kwargs)
 
 
 class ReplaceFunFonts(BaseTransform):
@@ -572,6 +585,7 @@ class ReplaceFunFonts(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Replaces words or characters depending on the granularity with fun fonts applied
@@ -582,20 +596,12 @@ class ReplaceFunFonts(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.replace_fun_fonts(
-            texts,
-            aug_p=self.aug_p,
-            aug_min=self.aug_min,
-            aug_max=self.aug_max,
-            granularity=self.granularity,
-            vary_fonts=self.vary_fonts,
-            fonts_path=self.fonts_path,
-            n=self.n,
-            priority_words=self.priority_words,
-            metadata=metadata,
-        )
+        return F.replace_fun_fonts(texts, metadata=metadata, **aug_kwargs)
 
 
 class ReplaceSimilarChars(BaseTransform):
@@ -653,6 +659,7 @@ class ReplaceSimilarChars(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Replaces letters in each text with similar characters
@@ -663,22 +670,12 @@ class ReplaceSimilarChars(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.replace_similar_chars(
-            texts,
-            aug_char_p=self.aug_char_p,
-            aug_word_p=self.aug_word_p,
-            min_char=self.min_char,
-            aug_char_min=self.aug_char_min,
-            aug_char_max=self.aug_char_max,
-            aug_word_min=self.aug_word_min,
-            aug_word_max=self.aug_word_max,
-            n=self.n,
-            mapping_path=self.mapping_path,
-            priority_words=self.priority_words,
-            metadata=metadata,
-        )
+        return F.replace_similar_chars(texts, metadata=metadata, **aug_kwargs)
 
 
 class ReplaceSimilarUnicodeChars(BaseTransform):
@@ -736,6 +733,7 @@ class ReplaceSimilarUnicodeChars(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Replaces letters in each text with similar unicodes
@@ -746,22 +744,12 @@ class ReplaceSimilarUnicodeChars(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.replace_similar_unicode_chars(
-            texts,
-            aug_char_p=self.aug_char_p,
-            aug_word_p=self.aug_word_p,
-            min_char=self.min_char,
-            aug_char_min=self.aug_char_min,
-            aug_char_max=self.aug_char_max,
-            aug_word_min=self.aug_word_min,
-            aug_word_max=self.aug_word_max,
-            n=self.n,
-            mapping_path=self.mapping_path,
-            priority_words=self.priority_words,
-            metadata=metadata,
-        )
+        return F.replace_similar_unicode_chars(texts, metadata=metadata, **aug_kwargs)
 
 
 class ReplaceUpsideDown(BaseTransform):
@@ -799,6 +787,7 @@ class ReplaceUpsideDown(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Flips words in the text upside down depending on the granularity
@@ -809,17 +798,12 @@ class ReplaceUpsideDown(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.replace_upside_down(
-            texts,
-            aug_p=self.aug_p,
-            aug_min=self.aug_min,
-            aug_max=self.aug_max,
-            granularity=self.granularity,
-            n=self.n,
-            metadata=metadata,
-        )
+        return F.replace_upside_down(texts, metadata=metadata, **aug_kwargs)
 
 
 class ReplaceWords(BaseTransform):
@@ -866,6 +850,7 @@ class ReplaceWords(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Replaces words in each text based on a given mapping
@@ -876,19 +861,12 @@ class ReplaceWords(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.replace_words(
-            texts,
-            aug_word_p=self.aug_word_p,
-            aug_word_min=self.aug_word_min,
-            aug_word_max=self.aug_word_max,
-            n=self.n,
-            mapping=self.mapping,
-            priority_words=self.priority_words,
-            ignore_words=self.ignore_words,
-            metadata=metadata,
-        )
+        return F.replace_words(texts, metadata=metadata, **aug_kwargs)
 
 
 class SimulateTypos(BaseTransform):
@@ -957,6 +935,7 @@ class SimulateTypos(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Simulates typos in each text using misspellings, keyboard distance, and swapping.
@@ -972,23 +951,12 @@ class SimulateTypos(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.simulate_typos(
-            texts,
-            aug_char_p=self.aug_char_p,
-            aug_word_p=self.aug_word_p,
-            min_char=self.min_char,
-            aug_char_min=self.aug_char_min,
-            aug_char_max=self.aug_char_max,
-            aug_word_min=self.aug_word_min,
-            aug_word_max=self.aug_word_max,
-            n=self.n,
-            typo_type=self.typo_type,
-            misspelling_dict_path=self.misspelling_dict_path,
-            priority_words=self.priority_words,
-            metadata=metadata,
-        )
+        return F.simulate_typos(texts, metadata=metadata, **aug_kwargs)
 
 
 class SplitWords(BaseTransform):
@@ -1030,6 +998,7 @@ class SplitWords(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Splits words in the text into subwords
@@ -1040,18 +1009,12 @@ class SplitWords(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.split_words(
-            texts,
-            aug_word_p=self.aug_word_p,
-            min_char=self.min_char,
-            aug_word_min=self.aug_word_min,
-            aug_word_max=self.aug_word_max,
-            n=self.n,
-            priority_words=self.priority_words,
-            metadata=metadata,
-        )
+        return F.split_words(texts, metadata=metadata, **aug_kwargs)
 
 
 class SwapGenderedWords(BaseTransform):
@@ -1099,6 +1062,7 @@ class SwapGenderedWords(BaseTransform):
         self,
         texts: Union[str, List[str]],
         metadata: Optional[List[Dict[str, Any]]] = None,
+        **aug_kwargs,
     ) -> List[str]:
         """
         Replaces words in each text based on a provided `mapping`, which can either be a
@@ -1113,16 +1077,9 @@ class SwapGenderedWords(BaseTransform):
             including its name, the source & dest length, etc. will be appended to
             the inputted list. If set to None, no metadata will be appended or returned
 
+        @param aug_kwargs: kwargs to pass into the augmentation that will override values
+            set in __init__
+
         @returns: the list of augmented text documents
         """
-        return F.swap_gendered_words(
-            texts,
-            aug_word_p=self.aug_word_p,
-            aug_word_min=self.aug_word_min,
-            aug_word_max=self.aug_word_max,
-            n=self.n,
-            mapping=self.mapping,
-            priority_words=self.priority_words,
-            ignore_words=self.ignore_words,
-            metadata=metadata,
-        )
+        return F.swap_gendered_words(texts, metadata=metadata, **aug_kwargs)


### PR DESCRIPTION
Summary: Much simpler version of D31309584, to allow overriding transforms' kwargs in `__call__()`.

Reviewed By: jbitton

Differential Revision: D31570356

