### PR TITLE
Add error messages for easier debugging

### DIFF
--- a/augly/tests/audio_tests/base_unit_test.py
+++ b/augly/tests/audio_tests/base_unit_test.py
@@ -33,7 +33,7 @@ class BaseAudioUnitTest(unittest.TestCase):
             import augly.audio as audaugs
         except ImportError:
             self.fail("audaugs failed to import")
-        self.assertTrue(dir(audaugs))
+        self.assertTrue(dir(audaugs), "Audio directory does not exist")
 
     @classmethod
     def setUpClass(cls):
@@ -60,14 +60,21 @@ class BaseAudioUnitTest(unittest.TestCase):
                 aug_function(local_audio_path, output_path=tmpfile.name, **kwargs)
                 dst = librosa.load(tmpfile.name, sr=None, mono=False)[0]
 
-            self.assertTrue(are_equal_audios(dst, ref))
+            self.assertTrue(
+                are_equal_audios(dst, ref), "Expected and outputted audio do not match"
+            )
 
     def evaluate_class(self, transform_class: Callable[..., np.ndarray], fname: str):
         metadata = []
         audio, sample_rate = transform_class(
             self.audios[0], self.sample_rates[0], metadata
         )
-        self.assertEqual(metadata, self.metadata[fname])
+
+        self.assertEqual(
+            metadata,
+            self.metadata[fname],
+            "Expected and outputted metadata do not match",
+        )
 
         if audio.ndim > 1:
             audio = np.swapaxes(audio, 0, 1)
@@ -80,7 +87,9 @@ class BaseAudioUnitTest(unittest.TestCase):
             dst = librosa.load(tmpfile.name, sr=None, mono=False)[0]
 
         ref = self.get_ref_audio(fname)
-        self.assertTrue(are_equal_audios(dst, ref))
+        self.assertTrue(
+            are_equal_audios(dst, ref), "Expected and outputted audio do not match"
+        )
 
     def get_ref_audio(self, fname: str, folder: str = "mono") -> np.ndarray:
         local_ref_path = pathmgr.get_local_path(

--- a/augly/tests/image_tests/base_unit_test.py
+++ b/augly/tests/image_tests/base_unit_test.py
@@ -69,7 +69,7 @@ class BaseImageUnitTest(unittest.TestCase):
             import augly.image as imaugs
         except ImportError:
             self.fail("imaugs failed to import")
-        self.assertTrue(dir(imaugs))
+        self.assertTrue(dir(imaugs), "Image directory does not exist")
 
     @classmethod
     def setUpClass(cls):
@@ -88,8 +88,14 @@ class BaseImageUnitTest(unittest.TestCase):
             file_dst = Image.open(tmpfile.name)
 
         pil_dst = aug_function(self.img, **kwargs)
-        self.assertTrue(are_equal_images(pil_dst, ref))
-        self.assertTrue(are_equal_images(file_dst, ref))
+
+        self.assertTrue(
+            are_equal_images(pil_dst, ref), "Expected and outputted images do not match"
+        )
+        self.assertTrue(
+            are_equal_images(file_dst, ref),
+            "Expected and outputted images do not match",
+        )
 
     def evaluate_class(
         self,
@@ -106,12 +112,18 @@ class BaseImageUnitTest(unittest.TestCase):
         )
 
         if check_mode:
-            self.assertTrue(self.img.mode == dst.mode)
+            self.assertTrue(
+                self.img.mode == dst.mode,
+                "Expected and outputted image modes do not match",
+            )
 
         self.assertTrue(
-            are_equal_metadata(metadata, self.metadata[fname], metadata_exclude_keys)
+            are_equal_metadata(metadata, self.metadata[fname], metadata_exclude_keys),
+            "Expected and outputted metadata do not match",
         )
-        self.assertTrue(are_equal_images(dst, ref))
+        self.assertTrue(
+            are_equal_images(dst, ref), "Expected and outputted images do not match"
+        )
 
     def get_ref_image(self, fname: str) -> Image.Image:
         ref_img_name = f"test_{fname}.png"

--- a/augly/tests/video_tests/base_unit_test.py
+++ b/augly/tests/video_tests/base_unit_test.py
@@ -77,7 +77,7 @@ class BaseVideoUnitTest(unittest.TestCase):
             import augly.video as vidaugs
         except ImportError:
             self.fail("vidaugs failed to import")
-        self.assertTrue(dir(vidaugs))
+        self.assertTrue(dir(vidaugs), "Video directory does not exist")
 
     @classmethod
     def setUpClass(cls):
@@ -98,7 +98,10 @@ class BaseVideoUnitTest(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile(suffix=".mp4") as tmpfile:
             aug_function(output_path=tmpfile.name, **kwargs)
-            self.assertTrue(are_equal_videos(ref_vid_path, tmpfile.name))
+            self.assertTrue(
+                are_equal_videos(ref_vid_path, tmpfile.name),
+                "Expected and outputted videos do not match",
+            )
 
     def evaluate_class(
         self,
@@ -117,10 +120,13 @@ class BaseVideoUnitTest(unittest.TestCase):
             transform_class(
                 output_path=tmpfile.name, seed=seed, metadata=metadata, **kwargs
             )
-            self.assertTrue(os.path.exists(tmpfile.name))
+            self.assertTrue(
+                os.path.exists(tmpfile.name), "Output video file does not exist"
+            )
 
         self.assertTrue(
             are_equal_metadata(metadata, self.metadata[fname], metadata_exclude_keys),
+            "Expected and outputted metadata do not match",
         )
 
     def get_ref_video(self, fname: str) -> str:


### PR DESCRIPTION
Summary:
The `False is not True` error that occurs when the expected media/metadata doesn't match is hard to parse for our users. Let's add more detailed messaging such that it's easier to debug augmentations!

This change doesn't apply to the text library since those tests don't have a unified base test etc :)

Differential Revision: D32604698

