### PR TITLE
[README] Change local image paths to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.svg" alt="logo" width="70%" />
+  <img src="https://github.com/facebookresearch/AugLy/blob/main/logo.svg" alt="logo" width="70%" />
 </p>
 
 <div align="center">
@@ -29,7 +29,7 @@ AugLy is a data augmentations library that currently supports four modalities ([
 
 AugLy is a great library to utilize for augmenting your data in model training, or to evaluate the robustness gaps of your model! We designed AugLy to include many specific data augmentations that users perform in real life on internet platforms like Facebook's -- for example making an image into a meme, overlaying text/emojis on images/videos, reposting a screenshot from social media. While AugLy contains more generic data augmentations as well, it will be particularly useful to you if you're working on a problem like copy detection, hate speech detection, or copyright infringement where these "internet user" types of data augmentations are prevalent.
 
-![Visual](image_visual.png)
+![Visual](https://github.com/facebookresearch/AugLy/blob/main/image_visual.png)
 
 To see more examples of augmentations, open the Colab notebooks in the README for each modality! (e.g. image [README](augly/image) & [Colab](https://colab.research.google.com/github/facebookresearch/AugLy/blob/main/examples/AugLy_image.ipynb))
 


### PR DESCRIPTION
In order to get the images in our readme to populate in our pypi link (https://pypi.org/project/augly/), let's use URLs to our images instead of local, relative paths! I looked at the rich diff previews of my changes and the README looked the same!