### PR TITLE
Added spatial bbox helper

### DIFF
--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -458,9 +458,6 @@ def spatial_bbox_helper(
 
     array_image = np.array(aug_image)
 
-    # `np.where` returns the indices where `array_image[y][x][c] > 0`
-    # `white_y` & `white_x` are the y & x indices where at least one of the RGB
-    # channels is not 0 (i.e. the pixel at (x, y) is not black)
     white_y, white_x, _ = np.where(array_image > 0)
     min_x, max_x = np.min(white_x), np.max(white_x)
     min_y, max_y = np.min(white_y), np.max(white_y)

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -446,7 +446,11 @@ def rotate_bboxes_helper(
 
 
 def spatial_bbox_helper(
-    bbox: Tuple, src_w: int, src_h: int, aug_function: Callable, **kwargs
+    bbox: Tuple[float, float, float, float],
+    src_w: int,
+    src_h: int,
+    aug_function: Callable,
+    **kwargs,
 ) -> Tuple:
     """
     Computes the bbox that encloses the transformed bbox in the image transformed by
@@ -457,7 +461,7 @@ def spatial_bbox_helper(
     dummy_image = Image.new("RGB", (src_w, src_h))
     draw = ImageDraw.Draw(dummy_image)
     draw.rectangle(
-        [bbox[0] * src_w, bbox[1] * src_h, bbox[2] * src_w, bbox[3] * src_h],
+        (bbox[0] * src_w, bbox[1] * src_h, bbox[2] * src_w, bbox[3] * src_h),
         fill="white",
     )
 

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -2,6 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
+from PIL import Image
 from typing import List, Optional, Tuple, Callable
 
 import augly.image.utils as imutils
@@ -445,15 +446,14 @@ def rotate_bboxes_helper(
 
 
 def spatial_bbox_helper(
-    bbox: Tuple, src_w: int, src_h: int, aug_function: Callable, **kwargs
+    bbox: Tuple, image: Image.Image, aug_function: Callable, **kwargs
 ) -> Tuple:
     """
-    Computes the bbox that encloses a white box in a black background
+    Computes the bbox that encloses a white box in a black backgtround
     for any augmentation.
     """
-    dummy_image = create_test_image(w=src_w, h=src_h, bbox=bbox)
 
-    aug_image = aug_function(dummy_image, **kwargs)
+    aug_image = aug_function(image, **kwargs)
     aug_w, aug_h = aug_image.size
 
     array_image = np.array(aug_image)

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -2,11 +2,11 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
-from PIL import Image, ImageDraw
 from typing import Callable, List, Optional, Tuple
 
 import augly.image.utils as imutils
 import numpy as np
+from PIL import Image, ImageDraw
 
 
 def crop_bboxes_helper(

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -455,7 +455,7 @@ def spatial_bbox_helper(
     augmentation).
     """
     dummy_image = Image.new("RGB", (src_w, src_h))
-    draw = ImageDraw.Draw(image)
+    draw = ImageDraw.Draw(dummy_image)
     draw.rectangle(
         [bbox[0] * src_w, bbox[1] * src_h, bbox[2] * src_w, bbox[3] * src_h],
         fill="white",

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Callable
 
 import augly.image.utils as imutils
 import numpy as np
@@ -448,7 +448,7 @@ def spatial_bbox_helper(
     bbox: Tuple, src_w: int, src_h: int, aug_function: Callable, **kwargs
 ) -> Tuple:
     """
-    Computes the bbox that encloses a white box in a black backgtround
+    Computes the bbox that encloses a white box in a black background
     for any augmentation.
     """
     dummy_image = create_test_image(w=src_w, h=src_h, bbox=bbox)

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -3,7 +3,7 @@
 
 import math
 from PIL import Image
-from typing import List, Optional, Tuple, Callable
+from typing import Callable, List, Optional, Tuple
 
 import augly.image.utils as imutils
 import numpy as np

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -9,16 +9,6 @@ import augly.image.utils as imutils
 import numpy as np
 
 
-def create_test_image(w: int, h: int, bbox: Tuple) -> Image.Image:
-    """
-    Create dummy test image to help spatial_bbox_helper.
-    """
-    image = Image.new("RGB", (w, h))
-    draw = ImageDraw.Draw(image)
-    draw.rectangle([bbox[0] * w, bbox[1] * h, bbox[2] * w, bbox[3] * h], fill="white")
-    return image
-
-
 def crop_bboxes_helper(
     bbox: Tuple, x1: float, y1: float, x2: float, y2: float, **kwargs
 ) -> Tuple:
@@ -464,7 +454,9 @@ def spatial_bbox_helper(
     augmentation which doesn't affect the color of the source image (e.g. any spatial
     augmentation).
     """
-    dummy_image = create_test_image(w=src_w, h=src_h, bbox=bbox)
+    dummy_image = Image.new("RGB", (w, h))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle([bbox[0] * w, bbox[1] * h, bbox[2] * w, bbox[3] * h], fill="white")
 
     aug_image = aug_function(dummy_image, **kwargs)
     aug_w, aug_h = aug_image.size

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -456,7 +456,10 @@ def spatial_bbox_helper(
     """
     dummy_image = Image.new("RGB", (src_w, src_h))
     draw = ImageDraw.Draw(image)
-    draw.rectangle([bbox[0] * src_w, bbox[1] * src_h, bbox[2] * src_w, bbox[3] * src_h], fill="white")
+    draw.rectangle(
+        [bbox[0] * src_w, bbox[1] * src_h, bbox[2] * src_w, bbox[3] * src_h],
+        fill="white",
+    )
 
     aug_image = aug_function(dummy_image, **kwargs)
     aug_w, aug_h = aug_image.size

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -473,8 +473,7 @@ def spatial_bbox_helper(
     min_x, max_x = np.min(white_x), np.max(white_x)
     min_y, max_y = np.min(white_y), np.max(white_y)
 
-    new_bbox = (min_x / aug_w, min_y / aug_h, max_x / aug_w, max_y / aug_h)
-    return new_bbox
+    return (min_x / aug_w, min_y / aug_h, max_x / aug_w, max_y / aug_h)
 
 
 def vflip_bboxes_helper(bbox: Tuple, **kwargs) -> Tuple:

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -2,7 +2,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 
 import math
-from PIL import Image
+from PIL import Image, ImageDraw
 from typing import Callable, List, Optional, Tuple
 
 import augly.image.utils as imutils

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -454,9 +454,9 @@ def spatial_bbox_helper(
     augmentation which doesn't affect the color of the source image (e.g. any spatial
     augmentation).
     """
-    dummy_image = Image.new("RGB", (w, h))
+    dummy_image = Image.new("RGB", (src_w, src_h))
     draw = ImageDraw.Draw(image)
-    draw.rectangle([bbox[0] * w, bbox[1] * h, bbox[2] * w, bbox[3] * h], fill="white")
+    draw.rectangle([bbox[0] * src_w, bbox[1] * src_h, bbox[2] * src_w, bbox[3] * src_h], fill="white")
 
     aug_image = aug_function(dummy_image, **kwargs)
     aug_w, aug_h = aug_image.size

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -9,6 +9,18 @@ import augly.image.utils as imutils
 import numpy as np
 
 
+def create_test_image(w: int, h: int, bbox: Tuple) -> Image.Image:
+    """
+    Create dummy test image to help spatial_bbox_helper. 
+    """
+    image = Image.new("RGB", (w, h))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle(
+        [bbox[0] * w, bbox[1] * h, bbox[2] * w, bbox[3] * h], fill="white"
+    )
+    return image
+
+
 def crop_bboxes_helper(
     bbox: Tuple, x1: float, y1: float, x2: float, y2: float, **kwargs
 ) -> Tuple:
@@ -446,14 +458,17 @@ def rotate_bboxes_helper(
 
 
 def spatial_bbox_helper(
-    bbox: Tuple, image: Image.Image, aug_function: Callable, **kwargs
+    bbox: Tuple, src_w: int, src_h: int, aug_function: Callable, **kwargs
 ) -> Tuple:
     """
-    Computes the bbox that encloses a white box in a black backgtround
-    for any augmentation.
+    Computes the bbox that encloses the transformed bbox in the image transformed by
+    `aug_function`. This helper can be used to compute the transformed bbox for any
+    augmentation which doesn't affect the color of the source image (e.g. any spatial
+    augmentation).
     """
+    dummy_image = create_test_image(w=src_w, h=src_h, bbox=bbox)
 
-    aug_image = aug_function(image, **kwargs)
+    aug_image = aug_function(dummy_image, **kwargs)
     aug_w, aug_h = aug_image.size
     array_image = np.array(aug_image)
 

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -455,7 +455,6 @@ def spatial_bbox_helper(
 
     aug_image = aug_function(image, **kwargs)
     aug_w, aug_h = aug_image.size
-
     array_image = np.array(aug_image)
 
     white_y, white_x, _ = np.where(array_image > 0)

--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -11,13 +11,11 @@ import numpy as np
 
 def create_test_image(w: int, h: int, bbox: Tuple) -> Image.Image:
     """
-    Create dummy test image to help spatial_bbox_helper. 
+    Create dummy test image to help spatial_bbox_helper.
     """
     image = Image.new("RGB", (w, h))
     draw = ImageDraw.Draw(image)
-    draw.rectangle(
-        [bbox[0] * w, bbox[1] * h, bbox[2] * w, bbox[3] * h], fill="white"
-    )
+    draw.rectangle([bbox[0] * w, bbox[1] * h, bbox[2] * w, bbox[3] * h], fill="white")
     return image
 
 


### PR DESCRIPTION
## Summary
- [x] I have read CONTRIBUTING.md to understand how to contribute to this repository :)

Computes the bbox that encloses a white box in a black background for any augmentation.


### Image
```bash
python -m unittest discover -s augly/tests/image_tests/ -p "*_test.py"
# Or `python -m unittest discover -s augly/tests/image_tests/ -p "*.py"` to run pytorch test too (must install `torchvision` to run)
```
```
Ran 82 tests in 53.014s

OK (skipped=5)
```

## Other testing

Colab notebook testing the bbox helper → https://colab.research.google.com/drive/1g_0I6f_bv4Wsna6l9jjZrOJ62a4dpu8U#scrollTo=yUczCe6FU9Bs
