### PR TITLE
BE clean up

### DIFF
--- a/augly/audio/functional.py
+++ b/augly/audio/functional.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-import math
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
@@ -460,18 +459,19 @@ def high_pass_filter(
     aug_audio, out_sample_rate = sox_effects.apply_effects_tensor(
         torch.Tensor(audio), sample_rate, [["highpass", str(cutoff_hz)]]
     )
+    high_pass_array = aug_audio.numpy()
 
     if metadata is not None:
         audutils.get_metadata(
             metadata=metadata,
             function_name="high_pass_filter",
-            dst_audio=aug_audio,
+            dst_audio=high_pass_array,
             dst_sample_rate=out_sample_rate,
             # pyre-fixme[61]: `func_kwargs` may not be initialized here.
             **func_kwargs,
         )
 
-    return audutils.ret_and_save_audio(aug_audio, output_path, out_sample_rate)
+    return audutils.ret_and_save_audio(high_pass_array, output_path, out_sample_rate)
 
 
 def insert_in_background(
@@ -690,18 +690,19 @@ def low_pass_filter(
     aug_audio, out_sample_rate = sox_effects.apply_effects_tensor(
         torch.Tensor(audio), sample_rate, [["lowpass", str(cutoff_hz)]]
     )
+    low_pass_array = aug_audio.numpy()
 
     if metadata is not None:
         audutils.get_metadata(
             metadata=metadata,
             function_name="low_pass_filter",
-            dst_audio=aug_audio,
+            dst_audio=low_pass_array,
             dst_sample_rate=out_sample_rate,
             # pyre-fixme[61]: `func_kwargs` may not be initialized here.
             **func_kwargs,
         )
 
-    return audutils.ret_and_save_audio(aug_audio, output_path, out_sample_rate)
+    return audutils.ret_and_save_audio(low_pass_array, output_path, out_sample_rate)
 
 
 def normalize(

--- a/augly/video/augmenters/ffmpeg/hflip.py
+++ b/augly/video/augmenters/ffmpeg/hflip.py
@@ -16,7 +16,7 @@ class VideoAugmenterByHFlip(BaseVidgearFFMPEGAugmenter):
         @param output_path: the path in which the resulting video will be stored.
 
         @returns: a list of strings containing the CLI FFMPEG command for
-            the augmentation in a command line
+            the augmentation
         """
         command = [
             "-y",

--- a/augly/video/helpers/ffmpeg.py
+++ b/augly/video/helpers/ffmpeg.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright (c) Facebook, Inc. and its affiliates.
 
-import io
 import math
 import os
 import shutil
@@ -13,7 +12,6 @@ import numpy as np
 from augly.audio import utils as audutils
 from augly.utils import pathmgr, SILENT_AUDIO_PATH
 from augly.utils.ffmpeg import FFMPEG_PATH, FFPROBE_PATH
-from ffmpeg.nodes import FilterableStream
 from vidgear.gears import WriteGear
 
 


### PR DESCRIPTION
Summary:
- Verified that `sf.write()` still works for low & high pass filters without reshape in `ret_and_save_audio()` (tested this by commenting out the try/except statement & only calling `sf.write()`, and the tests still passed.
- Convert audio tensor to numpy before passing into `ret_and_save_audio` -- even though it was still working, I think it's better style to convert to numpy since `ret_and_save_audio` expects `audio` to be type `np.ndarray`, in case we ever add processing in there that works on np arrays but not tensors.
- Ran `arc lint` on `aml/augly/audio/*.py` and same with `image/`, `image/utils/`, `text/`, `text/augmenters/`, `utils/`, `video/`, `video/augmenters/`, & `video/helpers/` (removed unused imports).
- Fixed comment flagged by jbitton in D32591542 (https://github.com/facebookresearch/AugLy/commit/35a6a5de07e64f465b8979e3257218551929e57a).

Differential Revision: D33088916

