### PR TITLE
Fix for rotating bounding box the wrong way

### DIFF
--- a/augly/image/utils/bboxes.py
+++ b/augly/image/utils/bboxes.py
@@ -400,8 +400,8 @@ def rotate_bboxes_helper(
         round(math.cos(angle_rad), 15),
         round(math.sin(angle_rad), 15),
         0.0,
-        round(-math.sin(angle_rad), 15),
-        round(math.cos(angle_rad), 15),
+        round(math.sin(angle_rad), 15),
+        round(-math.cos(angle_rad), 15),
         0.0,
     ]
     rotation_matrix[2], rotation_matrix[5] = transform(


### PR DESCRIPTION
## Summary
- [x] I have read CONTRIBUTING.md to understand how to contribute to this repository :)

The current method for rotating bounding boxes was bugged because it rotated the bounding box in the wrong direction. This simple sign change fixes it.

Test case: https://github.com/juliusfrost/AugLy/blob/rotate-bounding-box-jupyter/examples/test_rotate.ipynb

## Unit Tests
Passes unit tests.