### PR TITLE
Harmonize fetching of duration for temporal filters. (#223)

### DIFF
--- a/augly/tests/assets/expected_metadata/video_tests/expected_metadata.json
+++ b/augly/tests/assets/expected_metadata/video_tests/expected_metadata.json
@@ -606,7 +606,6 @@
             ],
             "dst_width": 1920,
             "intensity": 50.35715346534653,
-            "local_path": null,
             "name": "insert_in_background",
             "offset_factor": 0.25,
             "seed": null,

--- a/augly/video/functional.py
+++ b/augly/video/functional.py
@@ -801,8 +801,6 @@ def insert_in_background(
 
     @returns: the path to the augmented video
     """
-    local_path = utils.pathmgr.get_local_path(video_path)
-    utils.validate_video_path(local_path)
     assert (
         0.0 <= offset_factor <= 1.0
     ), "Offset factor must be a value in the range [0.0, 1.0]"
@@ -812,7 +810,9 @@ def insert_in_background(
             0.0 <= source_percentage <= 1.0
         ), "Source percentage must be a value in the range [0.0, 1.0]"
 
-    func_kwargs = helpers.get_func_kwargs(metadata, locals(), local_path)
+    func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
+    local_path = utils.pathmgr.get_local_path(video_path)
+    utils.validate_video_path(local_path)
 
     video_info = helpers.get_video_info(local_path)
     video_duration = float(video_info["duration"])
@@ -935,7 +935,6 @@ def replace_with_background(
 
     @returns: the path to the augmented video
     """
-    utils.validate_video_path(video_path)
     assert (
         0.0 <= source_offset <= 1.0
     ), "Source offset factor must be a value in the range [0.0, 1.0]"
@@ -949,6 +948,8 @@ def replace_with_background(
     ), "Source percentage must be a value in the range [0.0, 1.0]"
 
     func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
+    local_path = utils.pathmgr.get_local_path(video_path)
+    utils.validate_video_path(local_path)
 
     video_info = helpers.get_video_info(video_path)
     video_duration = float(video_info["duration"])
@@ -2103,12 +2104,13 @@ def time_decimate(
     """
     assert 0 < on_factor <= 1, "on_factor must be a value in the range (0, 1]"
     assert 0 <= off_factor <= 1, "off_factor must be a value in the range [0, 1]"
-    utils.validate_video_path(video_path)
 
     func_kwargs = helpers.get_func_kwargs(metadata, locals(), video_path)
+    local_path = utils.pathmgr.get_local_path(video_path)
+    utils.validate_video_path(local_path)
 
-    video_info = helpers.get_video_info(video_path)
-    _, video_ext = os.path.splitext(video_path)
+    video_info = helpers.get_video_info(local_path)
+    _, video_ext = os.path.splitext(local_path)
 
     duration = float(video_info["duration"])
     on_segment = duration * on_factor
@@ -2121,13 +2123,14 @@ def time_decimate(
     # subclips: 0->a, a+b -> 2*a + b, 2a+2b -> 3a+2b, .., na+nb -> (n+1)a + nb
     with tempfile.TemporaryDirectory() as tmpdir:
         for i in range(n):
-            subclips.append(os.path.join(tmpdir, f"{i}{video_ext}"))
+            clip_path = os.path.join(tmpdir, f"{i}{video_ext}")
             trim(
                 video_path,
-                subclips[-1],
+                clip_path,
                 start=i * on_segment + i * off_segment,
                 end=min(duration, (i + 1) * on_segment + i * off_segment),
             )
+            subclips.append(clip_path)
 
         concat(
             subclips,


### PR DESCRIPTION
Summary:
Made sure that `insert_in_background`, `replace_with_background` and `time_decimate` have consistent handling of remote (e.g. Manifold) input paths.

Pull Request resolved: https://github.com/facebookresearch/AugLy/pull/223

Differential Revision: D37811214

Pulled By: gpostelnicu

