### PR TITLE
Instrumented transitions into segments calculation.

### DIFF
--- a/augly/tests/video_tests/metadata_unit_test.py
+++ b/augly/tests/video_tests/metadata_unit_test.py
@@ -7,23 +7,184 @@
 
 import unittest
 from typing import List
-
-import augly.video.helpers as helpers
+from unittest.mock import MagicMock, patch
 
 from augly.utils import Segment
+from augly.video import helpers
+
+from augly.video.augmenters import ffmpeg as af
 
 
 class MetadataUnitTest(unittest.TestCase):
     def assert_equal_segments(self, actual: Segment, expected: Segment):
-        self.assertAlmostEqual(actual.start, expected.start)
-        self.assertAlmostEqual(actual.end, expected.end)
+        fail_msg = f"actual={actual}, expected={expected}"
+        self.assertAlmostEqual(actual.start, expected.start, msg=fail_msg)
+        self.assertAlmostEqual(actual.end, expected.end, msg=fail_msg)
 
     def assert_equal_segment_lists(
         self, actual: List[Segment], expected: List[Segment]
     ):
-        self.assertEqual(len(actual), len(expected))
+        self.assertEqual(
+            len(actual), len(expected), f"actuals={actual}, expected={expected}"
+        )
         for act, exp in zip(actual, expected):
             self.assert_equal_segments(act, exp)
+
+    def test_insert_in_background_transitions_start(self):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "insert_in_background",
+            src_duration=20.0,
+            dst_duration=26.0,
+            src_fps=25,
+            dst_fps=30,
+            metadata=None,
+            offset_factor=0.0,
+            background_video_duration=10.0,
+            source_percentage=None,
+            transition_before=False,
+            transition_after=True,
+            transition=af.TransitionConfig(
+                effect=af.TransitionEffect.CIRCLECLOSE, duration=4.0
+            ),
+        )
+        self.assert_equal_segment_lists(
+            new_src_segments, [Segment(start=0.0, end=18.0)]
+        )
+        self.assert_equal_segment_lists(
+            new_dst_segments, [Segment(start=0.0, end=18.0)]
+        )
+
+    def test_insert_in_background_transitions_end(self):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "insert_in_background",
+            src_duration=20.0,
+            dst_duration=26.0,
+            src_fps=25,
+            dst_fps=30,
+            metadata=None,
+            offset_factor=1.0,
+            background_video_duration=10.0,
+            source_percentage=None,
+            transition_before=True,
+            transition_after=False,
+            transition=af.TransitionConfig(
+                effect=af.TransitionEffect.CIRCLECLOSE, duration=4.0
+            ),
+        )
+        self.assert_equal_segment_lists(
+            new_src_segments, [Segment(start=2.0, end=20.0)]
+        )
+        self.assert_equal_segment_lists(
+            new_dst_segments, [Segment(start=8.0, end=26.0)]
+        )
+
+    def test_insert_in_background_transitions(self):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "insert_in_background",
+            src_duration=20.0,
+            dst_duration=22.0,
+            src_fps=25,
+            dst_fps=30,
+            metadata=None,
+            offset_factor=0.5,
+            background_video_duration=10.0,
+            source_percentage=None,
+            transition_before=True,
+            transition_after=True,
+            transition=af.TransitionConfig(
+                effect=af.TransitionEffect.CIRCLECLOSE, duration=4.0
+            ),
+        )
+        self.assert_equal_segment_lists(
+            new_src_segments, [Segment(start=2.0, end=18.0)]
+        )
+        self.assert_equal_segment_lists(
+            new_dst_segments, [Segment(start=3.0, end=19.0)]
+        )
+
+    def test_insert_in_background(self):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "insert_in_background",
+            src_duration=20.0,
+            dst_duration=30.0,
+            src_fps=25,
+            dst_fps=30,
+            metadata=None,
+            offset_factor=0.5,
+            background_video_duration=10.0,
+            source_percentage=None,
+            transition_before=True,
+            transition_after=True,
+            transition=None,
+        )
+        self.assert_equal_segment_lists(
+            new_src_segments, [Segment(start=0.0, end=20.0)]
+        )
+        self.assert_equal_segment_lists(
+            new_dst_segments, [Segment(start=5.0, end=25.0)]
+        )
+
+    def test_time_decimate(self):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "time_decimate",
+            src_duration=20,
+            dst_duration=12,
+            src_fps=25.0,
+            dst_fps=30.0,
+            metadata=None,
+            start_offset_factor=0.1,  # 2sec
+            on_factor=0.2,  # 4sec
+            off_factor=0.5,  # 2sec (relative to on_factor)
+            transition=None,
+        )
+        self.assert_equal_segment_lists(
+            new_src_segments,
+            [
+                Segment(start=2.0, end=6.0),
+                Segment(start=8.0, end=12.0),
+                Segment(start=14.0, end=18.0),
+            ],
+        )
+        self.assert_equal_segment_lists(
+            new_dst_segments,
+            [
+                Segment(start=0, end=4.0),
+                Segment(start=4.0, end=8.0),
+                Segment(start=8.0, end=12.0),
+            ],
+        )
+
+    def test_time_decimate_with_transition(self):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "time_decimate",
+            src_duration=20,
+            dst_duration=8,
+            src_fps=25.0,
+            dst_fps=30.0,
+            metadata=None,
+            start_offset_factor=0.1,  # 2sec
+            on_factor=0.2,  # 4sec
+            off_factor=0.5,  # 2sec (relative to on_factor)
+            transition=af.TransitionConfig(
+                effect=af.TransitionEffect.CIRCLECLOSE, duration=2.0
+            ),
+        )
+        self.assert_equal_segment_lists(
+            new_src_segments,
+            [
+                Segment(start=2.0, end=5.0),
+                Segment(start=9.0, end=11.0),
+                Segment(start=15.0, end=18.0),
+            ],
+        )
+        self.assert_equal_segment_lists(
+            new_dst_segments,
+            [
+                Segment(start=0, end=3.0),
+                Segment(start=3.0, end=5.0),
+                Segment(start=5.0, end=8.0),
+            ],
+        )
 
     def test_change_video_speed(self):
         md = {
@@ -88,4 +249,57 @@ class MetadataUnitTest(unittest.TestCase):
                 Segment(start=6.105361805127275, end=16.169474007566283),
                 Segment(start=16.169474007566283, end=26.233586210005278),
             ],
+        )
+
+    @patch(
+        "augly.video.helpers.get_video_info",
+        side_effect=[
+            {"duration": "20.0"},
+        ],
+    )
+    def test_concat_transition_video_in_the_middle(
+        self, mock_get_video_info: MagicMock
+    ):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "concat",
+            src_duration=30.0,
+            dst_duration=52.0,
+            src_fps=29.97,
+            dst_fps=30.0,
+            metadata=None,
+            video_paths=["before", "main", "after"],
+            src_video_path_index=1,
+            transition=af.TransitionConfig(
+                effect=af.TransitionEffect.CIRCLECLOSE, duration=4.0
+            ),
+        )
+
+        self.assert_equal_segment_lists(
+            new_src_segments, [Segment(start=2.0, end=28.0)]
+        )
+        assert mock_get_video_info.call_count == 1, mock_get_video_info.call_count
+        self.assert_equal_segment_lists(
+            new_dst_segments, [Segment(start=18.0, end=44.0)]
+        )
+
+    def test_concat_transition_main_video_first(self):
+        new_src_segments, new_dst_segments = helpers.compute_segments(
+            "concat",
+            src_duration=30.33,
+            dst_duration=64.8,
+            src_fps=29.97,
+            dst_fps=30.0,
+            metadata=None,
+            video_paths=["main", "after"],
+            src_video_path_index=0,
+            transition=af.TransitionConfig(
+                effect=af.TransitionEffect.CIRCLECLOSE, duration=4.0
+            ),
+        )
+
+        self.assert_equal_segment_lists(
+            new_src_segments, [Segment(start=0.0, end=28.33)]
+        )
+        self.assert_equal_segment_lists(
+            new_dst_segments, [Segment(start=0.0, end=28.33)]
         )

--- a/augly/video/functional.py
+++ b/augly/video/functional.py
@@ -831,9 +831,6 @@ def insert_in_background(
             helpers.create_color_video(resized_bg_path, video_duration, height, width)
         else:
             resize(background_path, resized_bg_path, height, width)
-            silent_bg_path = os.path.join(tmpdir, "silent.mp4")
-            helpers.add_silent_audio(resized_bg_path, silent_bg_path)
-            resized_bg_path = silent_bg_path
 
         bg_video_info = helpers.get_video_info(resized_bg_path)
         bg_video_duration = float(bg_video_info["duration"])
@@ -857,19 +854,24 @@ def insert_in_background(
 
         offset = desired_bg_duration * offset_factor
 
+        transition_before = False
         if offset > 0:
             before_path = os.path.join(tmpdir, "before.mp4")
             trim(resized_bg_path, before_path, start=bg_start, end=bg_start + offset)
             video_paths.append(before_path)
             src_video_path_index = 1
+            transition_before = True
         else:
             src_video_path_index = 0
 
         video_paths.append(tmp_video_path)
 
-        after_path = os.path.join(tmpdir, "after.mp4")
-        trim(resized_bg_path, after_path, start=bg_start + offset, end=bg_end)
-        video_paths.append(after_path)
+        transition_after = False
+        if bg_start + offset < bg_end:
+            after_path = os.path.join(tmpdir, "after.mp4")
+            trim(resized_bg_path, after_path, start=bg_start + offset, end=bg_end)
+            video_paths.append(after_path)
+            transition_after = True
 
         concat(
             video_paths,
@@ -883,6 +885,8 @@ def insert_in_background(
             metadata=metadata,
             function_name="insert_in_background",
             background_video_duration=desired_bg_duration,
+            transition_before=transition_before,
+            transition_after=transition_after,
             **func_kwargs,
         )
 


### PR DESCRIPTION
Summary:
Instrumented transitions in segment calculations, more specifically:
- `time_decimate`
- `insert_in_background`
- `concat`

I realized that transitions can be changed internally if one of the videos being concatenated is shorter than the desired transition duration. This may lead to incorrect segments, so the suggestion is to control for this during parameter sampling (another diff).

Differential Revision: D38116556

