### PR TITLE
Migrate to new rai_rs bucket

### DIFF
--- a/augly/tests/video_tests/metadata_unit_test.py
+++ b/augly/tests/video_tests/metadata_unit_test.py
@@ -5,11 +5,13 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import unittest
 from typing import List
 from unittest.mock import MagicMock, patch
 
 from augly.utils import Segment
+from augly.utils.base_paths import ASSETS_BASE_DIR
 from augly.video import helpers
 
 from augly.video.augmenters import ffmpeg as af
@@ -209,8 +211,14 @@ class MetadataUnitTest(unittest.TestCase):
             "text_change_nth": None,
             "fonts": [
                 (
-                    "manifold://ai_red_team/tree/similarity/media_assets/fonts/cac_champagne.ttf",
-                    "manifold://ai_red_team/tree/similarity/media_assets/fonts/cac_champagne.pkl",
+                    os.path.join(
+                        ASSETS_BASE_DIR,
+                        "similarity/media_assets/fonts/cac_champagne.ttf",
+                    ),
+                    os.path.join(
+                        ASSETS_BASE_DIR,
+                        "similarity/media_assets/fonts/cac_champagne.pkl",
+                    ),
                 )
             ],
             "fontscales": [0.2973747861954241, 0.5916911269561087],


### PR DESCRIPTION
Summary:
As part of the BE effort to deprecate the old `ai_red_team` Manifold bucket, we needed to move some assets used for AugLy to the new `rai_rs` bucket.
- Moved assets from `manifold://ai_red_team/tree/{augmentations,similarity,ocr}` --> `manifold://rai_rs/tree/augly/{augmentations,similarity,ocr}`.
- Changed the paths in the AugLy codebase to point to the new location of the assets.
- Changed fb text transforms tests to allow relative paths, same as the non-fb tests, to avoid this path change breaking some of the tests.
- Changed fb image transforms tests expected metadata to include relative paths, to avoid this path change breaking some of the tests.

Differential Revision: D38208863

