### PR TITLE
Resample background noise to seed audio's sample rate in add_background_noise

### DIFF
--- a/augly/audio/functional.py
+++ b/augly/audio/functional.py
@@ -18,7 +18,7 @@ from augly.utils.libsndfile import install_libsndfile
 install_libsndfile()
 import librosa
 from torchaudio import sox_effects
-from torchaudio.functional import fftconvolve
+from torchaudio.functional import fftconvolve, resample
 
 
 def add_background_noise(
@@ -71,7 +71,13 @@ def add_background_noise(
     if background_audio is None:
         background_audio = random_generator.standard_normal(audio.shape)
     else:
-        background_audio, _ = audutils.validate_and_load_audio(background_audio, 1)
+        background_audio, background_sr = audutils.validate_and_load_audio(
+            background_audio, sample_rate
+        )
+        if background_sr != sample_rate:
+            background_audio = resample(
+                torch.tensor(background_audio), background_sr, sample_rate
+            ).numpy()
 
     if metadata is not None:
         func_kwargs["background_duration"] = background_audio.shape[-1] / sample_rate


### PR DESCRIPTION
Summary: `add_background_noise` allows the caller to specify a path to load a noise waveform from. It's possible that the noise waveform and the seed audio to augment don't have the same sample rate. When this is the case, `add_background_noise` silently and unexpectedly adds the noise and audio with mismatched sample rates. To address this, this diff modifies `add_background_noise` to resample the noise waveform to the seed audio's sample rate.

Differential Revision: D45331594

