### PR TITLE
make image similarity check less sensitive

### DIFF
--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: '3.9'
       - run: sudo apt-get update
       - run: sudo apt-get install --fix-missing ffmpeg python3-soundfile
-      - run: pip install pyre-check pytest
+      - run: pip install pyre-check pytest imagehash
       - run: pip install -e .[all]
       - run: pyre --source-directory "." --noninteractive check || true
       - run: pytest --durations=10 .

--- a/augly/image/functional.py
+++ b/augly/image/functional.py
@@ -1712,7 +1712,9 @@ def overlay_wrap_text(
         color = (rand.randrange(255), rand.randrange(255), rand.randrange(255))
 
     red, green, blue = color
-    draw = ImageDraw.Draw(image)
+    aug_image = image.copy()
+
+    draw = ImageDraw.Draw(aug_image)
     for line in lines:
         # draw text on the image
         draw.text(
@@ -1726,11 +1728,11 @@ def overlay_wrap_text(
     imutils.get_metadata(
         metadata=metadata,
         function_name="overlay_wrap_text",
-        aug_image=image,
+        aug_image=aug_image,
         **func_kwargs,
     )
 
-    return imutils.ret_and_save_image(image, output_path, src_mode)
+    return imutils.ret_and_save_image(aug_image, output_path, src_mode)
 
 
 def pad(

--- a/augly/tests/image_tests/base_unit_test.py
+++ b/augly/tests/image_tests/base_unit_test.py
@@ -10,14 +10,17 @@ import tempfile
 import unittest
 from typing import Any, Callable, Dict, List, Optional
 
-import numpy as np
+import imagehash
 from augly.tests import ImageAugConfig
 from augly.utils import pathmgr, TEST_URI
 from PIL import Image
 
 
 def are_equal_images(a: Image.Image, b: Image.Image) -> bool:
-    return a.size == b.size and np.allclose(np.array(a), np.array(b))
+    threshold = 0  # hamming distance of 0 is forgiving enough for phash
+    a_hash = imagehash.phash(a)
+    b_hash = imagehash.phash(b)
+    return a.size == b.size and a_hash - b_hash == threshold
 
 
 def are_equal_metadata(


### PR DESCRIPTION
Summary:
as part of my personal side quest to make augly's tests pass again, i am making a change to our tests.

currently, to assess image similarity, we use the `np.allclose` function. while that's better / less sensitive than an MD5 hash it's not much better because imperceptible changes can actually have large differences in values between numpy image arrays.

thus, to make augly's tests less affected by slight version updates by PIL or whatever else, we are switching to using imagehash.

we're specifically using the phash - you can read about it here: https://www.hackerfactor.com/blog/index.php?/archives/432-Looks-Like-It.html

phash isn't a perfect fit though, long term. it's not sensitive to color, scaling, or aspect ratio changes. to deal with the latter two, im keeping in the size equality check. for color, i want to do some more research on what is an efficient way to do this. nonetheless, this is still better than what we currently have right now.

Differential Revision: D70137163
