### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,6 +4,10 @@ on:
     branches: main
   push:
     branches: main
+
+permissions:
+  contents: read
+
 jobs:
   lint_python:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_python.yml
+++ b/.github/workflows/test_python.yml
@@ -4,6 +4,10 @@ on:
     branches: main
   push:
     branches: main
+
+permissions:
+  contents: read
+
 jobs:
   test_python:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.